### PR TITLE
Adding int version of PDGid

### DIFF
--- a/particle/pdgid/pdgid.py
+++ b/particle/pdgid/pdgid.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 from . import functions as _functions
 
 
-class PDGID(object):
+class PDGID(int):
     """
     Holds a PDGID.
 
@@ -19,15 +19,15 @@ class PDGID(object):
     >>> PDGID(11).is_lepton
     True
     """
-    def __init__(self, pdgid):
-        self.pdgid = pdgid
-
     def __repr__(self):
-        return "<PDGID: {:d}{:s}>".format(self.pdgid,'' if self.is_valid else ' (is_valid==False)')
+        return "<PDGID: {:d}{:s}>".format(int(self),'' if self.is_valid else ' (is_valid==False)')
+
+    def __str__(self):
+        return repr(self)
 
 # Decorate the PDGID class with all relevant functions defined in the pdgid.functions module
 _exclude = ('IntEnum', 'Location' )
 _fname = [ fname for fname in dir(_functions) if not fname.startswith('_') and fname not in _exclude]
 for _n in _fname:
-    _decorator = property( lambda self, meth=getattr(_functions, _n) : meth(self.pdgid) )
+    _decorator = property( lambda self, meth=getattr(_functions, _n) : meth(self) )
     setattr(PDGID, _n, _decorator)

--- a/tests/pdgid/test_pdgid.py
+++ b/tests/pdgid/test_pdgid.py
@@ -7,11 +7,11 @@ from particle.pdgid import functions as _functions
 
 
 def test_class_methods():
-    id = PDGID(11)
-    assert id.pdgid == 11
-    assert id.__str__() == '<PDGID: 11>'
-    id = PDGID(-99999999)
-    assert id.__str__() == '<PDGID: -99999999 (is_valid==False)>'
+    pid = PDGID(11)
+    assert pid == 11
+    assert pid.__str__() == '<PDGID: 11>'
+    pid = PDGID(-99999999)
+    assert pid.__str__() == '<PDGID: -99999999 (is_valid==False)>'
 
 
 def test_decorated_class_methods(PDGIDs):
@@ -21,5 +21,5 @@ def test_decorated_class_methods(PDGIDs):
     """
     meths = [ m for m in PDGID.__dict__ if not m.startswith('_') ]
     for m in meths:
-        for id in PDGIDs:
-            assert getattr(PDGID(id),m) == getattr(_functions,m)(id)
+        for pid in PDGIDs:
+            assert getattr(PDGID(pid),m) == getattr(_functions,m)(pid)


### PR DESCRIPTION
This makes PDGids much simpler; they are just ints with some extra printing and method attached. No need to use `.pgdid` anymore. Comparisons, negation (such as in #9 ) are naturally supported.

This should nicely complement the new Particle class being moved from DecayLanguage.