### PR TITLE
Change spin definition

### DIFF
--- a/particle/pdgid/functions.py
+++ b/particle/pdgid/functions.py
@@ -13,7 +13,7 @@ HepPDT and HepPID versions 3.04.01: http://lcgapp.cern.ch/project/simu/HepPDT/
 """
 
 from __future__ import print_function, division, absolute_import
-from math import pow as _pow
+
 # Backport needed if Python 2 is used
 from enum import IntEnum
 
@@ -258,31 +258,31 @@ def three_charge(pdgid):
         else:     # not an ion
             return 0
     elif is_dyon(pdgid):            # Dyon
-         charge = 3*( (aid//10)%1000 )
-         # this is half right
-         # the charge sign will be changed below if pid < 0
-         if _digit(pdgid,Location.Nl) == 2:
-             charge = -charge
+        charge = 3*( (aid//10)%1000 )
+        # this is half right
+        # the charge sign will be changed below if pid < 0
+        if _digit(pdgid,Location.Nl) == 2:
+            charge = -charge
     elif sid > 0 and sid <= 100:        # use table
-         charge = ch100[sid-1]
-         if aid in (1000017, 1000018, 1000034, 1000052, 1000053, 1000054) : charge = 0
-         if aid == 5100061 or aid == 5100062 : charge = 6
+        charge = ch100[sid-1]
+        if aid in (1000017, 1000018, 1000034, 1000052, 1000053, 1000054) : charge = 0
+        if aid == 5100061 or aid == 5100062 : charge = 6
     elif _digit(pdgid,Location.Nj) == 0 :      # KL, Ks, or undefined
-         return 0
+        return 0
     elif q1 == 0 or (is_Rhadron(pdgid) and q1 == 9 ): # mesons
-         if q2 == 3 or q2 == 5 :
-             charge = ch100[q3-1] - ch100[q2-1]
-         else:
-             charge = ch100[q2-1] - ch100[q3-1]
+        if q2 == 3 or q2 == 5 :
+            charge = ch100[q3-1] - ch100[q2-1]
+        else:
+            charge = ch100[q2-1] - ch100[q3-1]
     elif q3 == 0:                       # diquarks
-         charge = ch100[q2-1] + ch100[q1-1]
+        charge = ch100[q2-1] + ch100[q1-1]
     elif is_baryon(pdgid) or (is_Rhadron(pdgid) and _digit(pdgid,Location.Nl) == 9) :  # baryons
-         charge = ch100[q3-1] + ch100[q2-1] + ch100[q1-1]
+        charge = ch100[q3-1] + ch100[q2-1] + ch100[q1-1]
     if charge == 0 : return 0
     elif pdgid < 0 : charge = -charge
     return charge
 
-def J(pdgid):
+def j_spin(pdgid):
     """Returns the total spin as 2J+1."""
     if _fundamental_id(pdgid)>0 and _fundamental_id(pdgid)<=100:
         fund = _fundamental_id(pdgid)
@@ -293,6 +293,14 @@ def J(pdgid):
         return 0
     elif _extra_bits(pdgid) > 0 : return 0
     return abspid(pdgid) % 10
+
+def J(pdgid):
+    """Returns total spin J.
+
+    This works due to the Python 3 style division."""
+
+    value = j_spin(pdgid)
+    return (value - 1) / 2 if value is not None else value
 
 def S(pdgid):
     """
@@ -323,7 +331,8 @@ def L(pdgid):
 
     nl = (abspid(pdgid)//10000) % 10
     js = abspid(pdgid) % 10
-    if (abspid(pdgid)//1000000)%10 == 9 : return 0
+    if (abspid(pdgid)//1000000) % 10 == 9 : return 0
+
     if nl == 0 and js == 3: return 0
     elif nl == 0 and js == 5: return 1
     elif nl == 0 and js == 7: return 2

--- a/particle/pdgid/pdgid.py
+++ b/particle/pdgid/pdgid.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import
 
 from . import functions as _functions
 
-# Collect all the relevant functions in the pdgid.functions module
-_exclude = ('IntEnum', 'Location', 'print_function', 'division', 'absolute_import')
-_fname = [ fname for fname in dir(_functions) if not fname.startswith('_') and fname not in _exclude]
+from inspect import isfunction
+
+# Collect all the user defined, non-hidden functions in the pdgid.functions module
+_fnames = [ fname for fname in dir(_functions) if not fname.startswith('_')
+                                                 and isfunction(getattr(_functions, fname))]
 
 class PDGID(int):
     """
@@ -41,6 +43,6 @@ class PDGID(int):
 
 
 # Decorate the PDGID class with all relevant functions defined in the pdgid.functions module
-for _n in _fname:
-    _decorator = property( lambda self, meth=getattr(_functions, _n) : meth(self) )
+for _n in _fnames:
+    _decorator = property(getattr(_functions, _n), doc=getattr(_functions, _n).__doc__)
     setattr(PDGID, _n, _decorator)

--- a/tests/pdgid/test_pdgid.py
+++ b/tests/pdgid/test_pdgid.py
@@ -3,7 +3,7 @@
 import pytest
 
 from particle.pdgid import PDGID
-from particle.pdgid.pdgid import _fname
+from particle.pdgid.pdgid import _fnames
 from particle.pdgid import functions as _functions
 
 
@@ -33,6 +33,6 @@ def test_decorated_class_methods(PDGIDs):
     Trivial check that all particle.pdgid functions decorated in the PDGID class
     work as expected for all kinds of PDGIDs.
     """
-    for m in _fname:
+    for m in _fnames:
         for pid in PDGIDs:
             assert getattr(PDGID(pid),m) == getattr(_functions,m)(pid)


### PR DESCRIPTION
This:

* Fixes some spacing and unneeded imports
* Changes the definition of J so it is the correct, fractional values (with j_spin taking on the old integer only values). Based on the [HepPDT names here](http://lcgapp.cern.ch/project/simu/HepPDT/HepPDT.3.03.00/html/ParticleIDMethods_8cc-source.html). Note that they are incorrect claiming `sSpin` and `lSpin` do the same trick; they do not.
* Simplified and propagated docstrings to properties
* Excluding non-functions is now automatic, rather than from an exclude list.