### PR TITLE
Add a Zenodo DOI tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
-.. image:: docs/ParticleLogo300.png
-    :alt: particle logo
+.. image:: https://github.com/scikit-hep/particle/raw/master/docs/ParticleLogo300.png
+    :alt: particle
+    :target: https://github.com/scikit-hep/particle
 
 Particle: PDG particle data and identification codes
 ====================================================
@@ -8,16 +9,19 @@ Particle: PDG particle data and identification codes
   :alt: PyPI
   :target: https://badge.fury.io/py/particle
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2552429.svg
+  :target: https://doi.org/10.5281/zenodo.2552429
+
 .. image:: https://dev.azure.com/scikit-hep/particle/_apis/build/status/scikit-hep.particle?branchName=master
   :alt: Build Status
   :target: https://dev.azure.com/scikit-hep/particle/_build/latest?definitionId=1?branchName=master
 
+.. image:: https://img.shields.io/azure-devops/coverage/scikit-hep/particle/1.svg
+  :alt: Coverage
+  :target: https://dev.azure.com/scikit-hep/particle/_build/latest?definitionId=1?branchName=master
+
 .. image:: https://img.shields.io/azure-devops/tests/scikit-hep/particle/1.svg
    :alt: Tests
-   :target: https://dev.azure.com/scikit-hep/particle/_build/latest?definitionId=1?branchName=master
-
-.. image:: https://img.shields.io/azure-devops/coverage/scikit-hep/particle/1.svg
-   :alt: Coverage
    :target: https://dev.azure.com/scikit-hep/particle/_build/latest?definitionId=1?branchName=master
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     classifiers = [
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Topic :: Scientific/Engineering :: Physics'
+        'Topic :: Scientific/Engineering',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',


### PR DESCRIPTION
For some reason the logo does not appear on PyPI for the 0.2.0 release.
I'm trying to fix that using the full path ...