### PR TITLE
Add lifetime to Particle class properties

### DIFF
--- a/particle/particle/kinematics.py
+++ b/particle/particle/kinematics.py
@@ -45,7 +45,7 @@ def width_to_lifetime(Gamma):
     """
 
     if Gamma <= 0.:
-        raise ValueError( 'Input provided, %s <= 0!'.format(Gamma) )
+        raise ValueError( 'Input provided, {0} <= 0!'.format(Gamma) )
 
     # Just need to first make sure that the width is in the standard unit MeV
     return hbar / float(Gamma / MeV)
@@ -86,7 +86,7 @@ def lifetime_to_width(tau):
     """
 
     if tau <= 0:
-        raise ValueError( 'Input provided, %s <= 0!'.format(tau) )
+        raise ValueError( 'Input provided, {0} <= 0!'.format(tau) )
 
     # Just need to first make sure that the lifetime is in the standard unit ns
     return hbar / float(tau / ns)

--- a/particle/particle/kinematics.py
+++ b/particle/particle/kinematics.py
@@ -21,7 +21,9 @@ def width_to_lifetime(Gamma):
 
     Returns
     -------
-    Particle lifetime, in the HEP standard time unit ns.
+    Gamma > 0: particle lifetime, in the HEP standard time unit ns.
+    Gamma = 0: Infinity (float("inf")).
+    Gamma < 0: an exception ValueError is raised.
 
     Examples
     --------
@@ -44,8 +46,10 @@ def width_to_lifetime(Gamma):
     1.520119980246514
     """
 
-    if Gamma <= 0.:
+    if Gamma < 0.:
         raise ValueError( 'Input provided, {0} <= 0!'.format(Gamma) )
+    elif Gamma == 0:
+        return float('inf')
 
     # Just need to first make sure that the width is in the standard unit MeV
     return hbar / float(Gamma / MeV)
@@ -63,6 +67,9 @@ def lifetime_to_width(tau):
     Returns
     -------
     Particle decay width, in the HEP standard energy unit MeV.
+    tau > 0: particle lifetime, in the HEP standard time unit ns.
+    tau = 0: Infinity (float("inf")).
+    tau < 0: an exception ValueError is raised.
 
     Examples
     --------
@@ -85,8 +92,10 @@ def lifetime_to_width(tau):
     0.000433
     """
 
-    if tau <= 0:
+    if tau < 0:
         raise ValueError( 'Input provided, {0} <= 0!'.format(tau) )
+    elif tau == 0:
+        return float('inf')
 
     # Just need to first make sure that the lifetime is in the standard unit ns
     return hbar / float(tau / ns)

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -15,6 +15,8 @@ from functools import reduce, total_ordering
 # External dependencies
 import attr
 
+from hepunits.constants import c_light
+
 from .. import data
 from ..pdgid import PDGID
 from ..pdgid import is_valid
@@ -174,6 +176,11 @@ class Particle(object):
     def lifetime(self):
         'The particle lifetime, in nanoseconds.'
         return width_to_lifetime(self.width)
+
+    @property
+    def ctau(self):
+        'The particle c*tau, in millimeters.'
+        return c_light*self.lifetime
 
     @property
     def radius(self):

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -25,12 +25,16 @@ from .enums import (SpinType, Parity, Charge, Inv, Status,
                     Charge_undo, Charge_prog, Charge_mapping)
 
 from .utilities import programmatic_name, str_with_unc
+from .kinematics import width_to_lifetime
+
 
 class ParticleNotFound(RuntimeError):
     pass
 
+
 class InvalidParticle(RuntimeError):
     pass
+
 
 @total_ordering
 @attr.s(slots=True, cmp=False, repr=False)
@@ -166,6 +170,10 @@ class Particle(object):
         'The particle charge (integer * 3).'
         return Charge(self.pdgid.three_charge)
 
+    @property
+    def lifetime(self):
+        'The particle lifetime, in nanoseconds.'
+        return width_to_lifetime(self.width)
 
     @property
     def radius(self):

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -232,27 +232,27 @@ class Particle(object):
         # name += "^{" +  Parity_undo[self.three_charge] + '}'
         return ("$" + name + '$') if self.latex else '?'
 
+    def _width_or_lifetime(self):
+        if self.width <= 0:
+            return 'Width = {width} MeV'.format(width=str(self.width))
+        elif self.width > 1.e-18:
+            if self.width_lower == self.width_upper:
+                e = width_to_lifetime(self.width-self.width_lower)-self.lifetime
+                s = 'Lifetime = {lifetime} ns'.format(lifetime=str_with_unc(self.lifetime,e,e))
+            else:
+                s = 'Lifetime = {lifetime} ns'.\
+                    format(lifetime=str_with_unc(self.lifetime,\
+                                                 width_to_lifetime(self.width-self.width_lower)-self.lifetime,
+                                                 self.lifetime-width_to_lifetime(self.width+self.width_upper)
+                                                 ))
+            return s
+        else:
+            return 'Width = {width} MeV'.format(width=str_with_unc(self.width, self.width_upper, self.width_lower))
+
     def describe(self):
         'Make a nice high-density string for a particle\'s properties.'
         if self.pdgid == 0:
             return "Name: Unknown"
-
-        def _width_or_lifetime():
-            if self.width <= 0:
-                return 'Width = {width} MeV'.format(width=str(self.width))
-            elif self.width > 1.e-18:
-                if self.width_lower == self.width_upper:
-                    e = width_to_lifetime(self.width-self.width_lower)-self.lifetime
-                    s = 'Lifetime = {lifetime} ns'.format(lifetime=str_with_unc(self.lifetime,e,e))
-                else:
-                    s = 'Lifetime = {lifetime} ns'.\
-                        format(lifetime=str_with_unc(self.lifetime,\
-                                                     width_to_lifetime(self.width-self.width_lower)-self.lifetime,
-                                                     self.lifetime-width_to_lifetime(self.width+self.width_upper)
-                                                     ))
-                return s
-            else:
-                return 'Width = {width} MeV'.format(width=str_with_unc(self.width, self.width_upper, self.width_lower))
 
         val = """Name: {self.name:<10} ID: {self.pdgid:<12} Fullname: {self!s:<14} Latex: {latex}
 Mass  = {mass} MeV
@@ -265,7 +265,7 @@ J (total angular) = {self.J!s:<6} C (charge parity) = {C:<5}  P (space parity) =
            Q=Charge_undo[self.three_charge],
            P=Parity_undo[self.P],
            mass=str_with_unc(self.mass, self.mass_upper, self.mass_lower),
-           width_or_lifetime=_width_or_lifetime(),
+           width_or_lifetime=self._width_or_lifetime(),
            latex = self._repr_latex_())
 
         if self.spin_type != SpinType.Unknown:

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -237,9 +237,26 @@ class Particle(object):
         if self.pdgid == 0:
             return "Name: Unknown"
 
+        def _width_or_lifetime():
+            if self.width <= 0:
+                return 'Width = {width} MeV'.format(width=str(self.width))
+            elif self.width > 1.e-18:
+                if self.width_lower == self.width_upper:
+                    e = width_to_lifetime(self.width-self.width_lower)-self.lifetime
+                    s = 'Lifetime = {lifetime} ns'.format(lifetime=str_with_unc(self.lifetime,e,e))
+                else:
+                    s = 'Lifetime = {lifetime} ns'.\
+                        format(lifetime=str_with_unc(self.lifetime,\
+                                                     width_to_lifetime(self.width-self.width_lower)-self.lifetime,
+                                                     self.lifetime-width_to_lifetime(self.width+self.width_upper)
+                                                     ))
+                return s
+            else:
+                return 'Width = {width} MeV'.format(width=str_with_unc(self.width, self.width_upper, self.width_lower))
+
         val = """Name: {self.name:<10} ID: {self.pdgid:<12} Fullname: {self!s:<14} Latex: {latex}
 Mass  = {mass} MeV
-Width = {width} MeV
+{width_or_lifetime}
 I (isospin)       = {self.I!s:<6} G (parity)        = {G:<5}  Q (charge)       = {Q}
 J (total angular) = {self.J!s:<6} C (charge parity) = {C:<5}  P (space parity) = {P}
 """.format(self=self,
@@ -248,7 +265,7 @@ J (total angular) = {self.J!s:<6} C (charge parity) = {C:<5}  P (space parity) =
            Q=Charge_undo[self.three_charge],
            P=Parity_undo[self.P],
            mass=str_with_unc(self.mass, self.mass_upper, self.mass_lower),
-           width=str_with_unc(self.width, self.width_upper, self.width_lower) if self.width >= 0 else self.width,
+           width_or_lifetime=_width_or_lifetime(),
            latex = self._repr_latex_())
 
         if self.spin_type != SpinType.Unknown:

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -1,4 +1,8 @@
-# Licensed under a 3-clause BSD style license, see LICENSE.
+# -*- encoding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+import sys
 
 import pytest
 from pytest import approx
@@ -86,6 +90,28 @@ def test_lifetime_props():
     pi = Particle.from_pdgid(211)
     assert pi.lifetime == approx(26.0327460625985)   # in nanoseconds
     assert pi.ctau == approx(7804.4209306)   # in millimeters
+
+
+def test_describe():
+    __description = u'Lifetime = 26.033 ± 0.005 ns'
+    if sys.version_info < (3,0):
+        __description = __description.replace(u'±', u'+/-')
+    pi = Particle.from_pdgid(211)
+    assert __description in pi.describe()
+
+    __description = """Name: gamma      ID: 22           Fullname: gamma0         Latex: $\gamma$
+Mass  = 0.0 MeV
+Width = 0.0 MeV
+I (isospin)       = <2     G (parity)        = 0      Q (charge)       = 0
+J (total angular) = 1.0    C (charge parity) = ?      P (space parity) = ?
+    Antiparticle status: Same (antiparticle name: gamma0)"""
+    photon = Particle.from_pdgid(22)
+    assert photon.describe() == __description
+
+    __description = 'Lifetime = 3.48e-13 + 3.7e-14 - 1.6e-14 ns'
+    Sigma_c_pp = Particle.from_pdgid(4222)
+    assert __description in Sigma_c_pp.describe()
+
 
 def test_ampgen_style_names():
     assert Particle.from_string('pi+').pdgid == 211

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -75,13 +75,17 @@ def test_rep():
     assert "mass=139.57" in repr(pi)
 
 
-def test_prop():
+def test_basic_props():
     pi = Particle.from_pdgid(211)
     assert pi.name == 'pi'
     assert pi.pdgid == 211
     assert pi.three_charge == Charge.p
-    assert pi.lifetime == approx(26.0327460625985)
 
+
+def test_lifetime_props():
+    pi = Particle.from_pdgid(211)
+    assert pi.lifetime == approx(26.0327460625985)   # in nanoseconds
+    assert pi.ctau == approx(7804.4209306)   # in millimeters
 
 def test_ampgen_style_names():
     assert Particle.from_string('pi+').pdgid == 211

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
 import pytest
+from pytest import approx
 
 from particle.particle.enums import Charge, Parity, SpinType
 from particle.particle import Particle
@@ -79,6 +80,7 @@ def test_prop():
     assert pi.name == 'pi'
     assert pi.pdgid == 211
     assert pi.three_charge == Charge.p
+    assert pi.lifetime == approx(26.0327460625985)
 
 
 def test_ampgen_style_names():
@@ -94,7 +96,6 @@ def test_ampgen_style_names():
 
     assert Particle.from_string('K(1)(1270)bar-') == -10323
     assert Particle.from_string('K(1460)bar-') == -100321
-
 
 
 def test_decfile_style_names():


### PR DESCRIPTION
This PR adds the lifetime as a `Particle` property, now that https://github.com/scikit-hep/particle/pull/45/ is sorted.

A few comments/questions for discussion:

- I could also trivially add c*tau, which is a very common quantity to calculate.
- the Particle class contains `width`, `width_lower` and `width_upper`. Shall I add the lower and upper too, for the lifetime?
- And where to print this info, as for now the `describe()` method prints the width info:
```
>>> print Particle.from_pdgid(511).describe()
Name: B          ID: 511          Fullname: B0             Latex: $B^{0}$
Mass  = 5279.63 +/- 0.15 MeV
Width = 4.330e-10 +/- 1.1e-12 MeV
I (isospin)       = 1/2    G (parity)        = 0      Q (charge)       = 0
J (total angular) = 0.0    C (charge parity) = 0      P (space parity) = ?
    Quarks: dB
    Antiparticle status: Full (antiparticle name: B~0)
```

Any preferences @henryiii and @HDembinski ?
