### PR TITLE
Doc and tests for Particle.spin_type

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,41 +1,47 @@
 Changelog
 =========
 
-Version 0.3.1
+Version 0.4.0
 -------------
 Under development
 
-* More package documentation.
+* Rename ``Particle.fullname/name`` to ``Particle.name/pdgname``.
+* More package documentation (data files, ``particle`` submodule).
+* Test suite of ``Particle`` class extended.
+* Rework for simpler usage of ``particle.particle.convert`` (non-public helper module).
 
 Version 0.3.0
 -------------
 March 6th, 2019
 
-* Particle search engine replaced with more intuitive and powerful version.
+* ``Particle`` search engine replaced with more intuitive and powerful version.
 * Various improvements in the handling of particle names and literals.
 * List of literals extended.
-* More documentation in Particle class.
+* More documentation in ``Particle`` class.
 * More tests; table generation is now tested as well.
 * Bug fixes in CSV data files and LaTeX naming updates.
 * Added missing particles for 2018 data files.
+
 
 Version 0.2.2
 -------------
 Feb 5th, 2019
 
-* Bug fix in setup.py.
+* Bug fix in ``setup.py``.
 * CHANGELOG file added.
+
 
 Version 0.2.1
 -------------
 Feb 4th, 2019
 
-* Particle now has direct lifetime and ctau access.
+* ``Particle`` now has direct lifetime and ctau access.
 * Better documentation.
-* Several bugs fixed in Particle and PDGID.
+* Several bugs fixed in ``Particle`` and ``PDGID``.
 * The minimum version of dependencies are now more accurate.
 
-The Scikit-HEP package hepunits is now a strict dependency.
+The Scikit-HEP package ``hepunits`` is now a strict dependency.
+
 
 Version 0.2.0
 -------------
@@ -43,6 +49,7 @@ Jan 29, 2019
 
 Particle provides a pythonic interface to the Particle Data Group (PDG)
 particle data tables and particle identification codes.
+
 
 Version 0.1.0
 -------------

--- a/particle/particle/enums.py
+++ b/particle/particle/enums.py
@@ -9,14 +9,20 @@ from enum import IntEnum
 
 
 class SpinType(IntEnum):
-    """Enum representing the spin type of a particle."""
-    Scalar = 1  # (0, 1)
+    """
+    Enum representing the spin type.
+
+    Relevant only for bosons. SpinType.NonDefined is to be used for non-bosons.
+    """
+    #          Values of (J, P)
+    Scalar = 1         # (0, 1)
     PseudoScalar = -1  # (0,-1)
-    Vector = 2  # (1,-1)
-    Axial = -2  # (1, 1)
-    Tensor = 3  # (2, 1)
+    Vector = 2         # (1,-1)
+    Axial = -2         # (1, 1)
+    Tensor = 3         # (2, 1)
     PseudoTensor = -3  # (2,-1)
-    Unknown = 0  # (0, 0)
+    Unknown = 0
+    NonDefined = 5
 
 
 class Parity(IntEnum):

--- a/particle/particle/enums.py
+++ b/particle/particle/enums.py
@@ -10,9 +10,10 @@ from enum import IntEnum
 
 class SpinType(IntEnum):
     """
-    Enum representing the spin type.
+    Enum representing the spin type. Relevant only for bosons.
 
-    Relevant only for bosons. SpinType.NonDefined is to be used for non-bosons.
+    SpinType.Unknown is returned for bosons if one of the values (J,P) is not known/relevant.
+    SpinType.NonDefined is to be used for non-bosons.
     """
     #          Values of (J, P)
     Scalar = 1         # (0, 1)

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -293,7 +293,15 @@ class Particle(object):
 
     @property
     def spin_type(self):  # -> SpinType:
-        'Access the SpinType enum.'
+        """
+        Access the SpinType enum.
+
+        Note that this is relevant for bosons only. SpinType.NonDefined is returned otherwise.
+        """
+        # Fermions - 2J+1 is always an even number
+        if self.pdgid.j_spin % 2 == 0:
+            return SpinType.NonDefined
+
         if self.J in [0, 1, 2]:
             J = int(self.J)
 

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -169,6 +169,45 @@ J (total angular) = 1.0    C (charge parity) = -      P (space parity) = -
     assert __description in Sigma_c_pp.describe()
 
 
+spin_type_classification = (
+    # Gauge bosons
+    (23, SpinType.Unknown),      # Z0 - no parity defined for it
+    # Leptons aren't assigned a SpinType
+    (11, SpinType.NonDefined),      # e-
+    # Only mesons are given a SpinType
+    # - Pseudo-scalars J^P = 0^-
+    (211, SpinType.PseudoScalar),   # pi+
+    (310, SpinType.PseudoScalar),   # K_S
+    (-421, SpinType.PseudoScalar),  # D0_bar
+    # - Scalars J^P = 0^+
+    (9000211, SpinType.Scalar),     # a_0(980)+
+    (9010221, SpinType.Scalar),     # f_0(980)
+    # - Vector J^P = 1^-
+    (333, SpinType.Vector),         # phi(1020)
+    (443, SpinType.Vector),         # J/psi
+    # Axial-vector - J^P = 1^+
+    (20213, SpinType.Axial),        # a_1(1260)+
+    (20313, SpinType.Axial),        # K_1(1400)0
+    (10433, SpinType.Axial),        # D_s1(2536)+
+    # Tensor - J^P = 2^+
+    (225, SpinType.Tensor),         # f_2(1270)
+    (315, SpinType.Tensor),         # K*_2(1430)0
+    # Pseudo-tensor - J^P = 2^-
+    (10225, SpinType.PseudoTensor), # eta_2(1645)
+    # J > 2 mesons
+    (329, SpinType.Unknown),        # K*_4(2045)+
+    # Baryons aren't assigned a SpinType
+    (2212, SpinType.NonDefined),    # proton
+)
+
+
+@pytest.mark.parametrize("pid,stype", spin_type_classification)
+def test_invert_related_methods(pid, stype):
+    particle = Particle.from_pdgid(pid)
+
+    assert particle.spin_type == stype
+
+
 ampgen_style_names = (
     ("pi+", 211),
     ("pi-", -211),


### PR DESCRIPTION
@henryiii, it is not clear where this property is taken from. From the PDG, I guess? I'm here adding doc and tests, extending a bit the function itself, following what seems reasonable to me. Can you point me to the PDG doc where you took `Particle.spin_type` `and `SpinType enum definitions from? Thanks.