### PR TITLE
Rename Particle.bar to Particle.is_name_barred

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@
     :alt: particle
     :target: https://github.com/scikit-hep/particle
 
+
 Particle: PDG particle data and identification codes
 ====================================================
 
@@ -40,6 +41,7 @@ The current version of the package reflects a pythonic version of the
 utility functions defined in HepPID and HepPDT versions 3.04.01,
 see http://lcgapp.cern.ch/project/simu/HepPDT/.
 
+
 Installation
 ------------
 
@@ -51,12 +53,14 @@ Install ``particle`` like any other Python package:
 
 or similar (use ``--user``, ``virtualenv``, etc. if you wish).
 
+
 Strict dependencies
 -------------------
 
 - `Python <http://docs.python-guide.org/en/latest/starting/installation/>`_ (2.7+, 3.5+)
 - `importlib_resources backport <http://importlib-resources.readthedocs.io/en/latest/>`_ if using Python < 3.7
 - `attrs <http://www.attrs.org/en/stable/>`_ provides classes without boilerplate (similar to DataClasses in Python 3.7)
+
 
 Getting started: PDGIDs
 -----------------------
@@ -144,7 +148,7 @@ match returned by the search, and will throw an error if more or less than one
 match is found.
 
 Once you have a particle, any of the properties can be accessed, along with several methods.
-Though they are not real properties, you can access ``bar``, ``radius``, and ``spin_type``.
+Though they are not real properties, you can access ``has_name_barred``, ``radius``, and ``spin_type``.
 You can also ``.invert()`` a particle.
 
 There are lots of printing choices for particles:

--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ match returned by the search, and will throw an error if more or less than one
 match is found.
 
 Once you have a particle, any of the properties can be accessed, along with several methods.
-Though they are not real properties, you can access ``has_name_barred``, ``radius``, and ``spin_type``.
+Though they are not real properties, you can access ``is_name_barred``, ``radius``, and ``spin_type``.
 You can also ``.invert()`` a particle.
 
 There are lots of printing choices for particles:

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -290,7 +290,7 @@ class Particle(object):
             return 1.5
 
     @property
-    def has_name_barred(self):
+    def is_name_barred(self):
         """
         Check to see if particle is inverted (hence is it an antiparticle)
         and has a bar in its name.

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -290,8 +290,11 @@ class Particle(object):
             return 1.5
 
     @property
-    def bar(self):
-        'Check to see if particle is inverted.'
+    def has_name_barred(self):
+        """
+        Check to see if particle is inverted (hence is it an antiparticle)
+        and has a bar in its name.
+        """
         return self.pdgid < 0 and self.anti_flag == Inv.Full
 
     @property
@@ -550,7 +553,7 @@ J (total angular) = {self.J!s:<6} C (charge parity) = {C:<5}  P (space parity) =
 
     @classmethod
     def from_string(cls, name):
-        'Get a particle from a PDG style name - returns best match'
+        'Get a particle from a PDG style name - returns the best match.'
         matches =  cls.from_string_list(name)
         if matches:
             return matches[0]
@@ -561,11 +564,7 @@ J (total angular) = {self.J!s:<6} C (charge parity) = {C:<5}  P (space parity) =
 
     @classmethod
     def from_string_list(cls, name):
-        'Get a list of particle from a PDG style name'
-
-        # Patch in common names
-        if name == 'Upsilon':
-            name = 'Upsilon(1S)'
+        'Get a list of particles from a PDG style name.'
 
         # Forcable override
         bar = False

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -168,7 +168,7 @@ J (total angular) = 1.0    C (charge parity) = -      P (space parity) = -
     Sigma_c_pp = Particle.from_pdgid(4222)
     assert __description in Sigma_c_pp.describe()
 
-checklist_has_name_barred = (
+checklist_is_name_barred = (
     (1, False),       # d quark
     (-2, True),       # u antiquark
     (11, False),      # e-
@@ -189,11 +189,11 @@ checklist_has_name_barred = (
 )
 
 
-@pytest.mark.parametrize("pid,has_bar", checklist_has_name_barred)
-def test_has_name_barred(pid, has_bar):
+@pytest.mark.parametrize("pid,has_bar", checklist_is_name_barred)
+def test_is_name_barred(pid, has_bar):
     particle = Particle.from_pdgid(pid)
 
-    assert particle.has_name_barred == has_bar
+    assert particle.is_name_barred == has_bar
 
 
 ampgen_style_names = (

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -168,6 +168,33 @@ J (total angular) = 1.0    C (charge parity) = -      P (space parity) = -
     Sigma_c_pp = Particle.from_pdgid(4222)
     assert __description in Sigma_c_pp.describe()
 
+checklist_has_name_barred = (
+    (1, False),       # d quark
+    (-2, True),       # u antiquark
+    (11, False),      # e-
+    (-13, False),     # mu+
+    (111, False),     # pi0
+    (211, False),     # pi+
+    (-211, False),    # pi-
+    (-213, False),    # rho(770)-
+    (443, False),     # J/psi
+    (300553, False),  # Upsilon(4S)
+    (130, False),     # K_L
+    (2212, False),    # proton
+    (-2112, True),    # antineutron
+    (3322, False),    # Xi0
+    (-3322, True),    # Xi0_bar
+    (-511, True),     # B0_bar
+    (-5122, True),    # Lb0_bar
+)
+
+
+@pytest.mark.parametrize("pid,has_bar", checklist_has_name_barred)
+def test_has_name_barred(pid, has_bar):
+    particle = Particle.from_pdgid(pid)
+
+    assert particle.has_name_barred == has_bar
+
 
 ampgen_style_names = (
     ("pi+", 211),


### PR DESCRIPTION
Another small change to the `Particle` API, @henryiii. Seems better.

All for the imminent release 0.4.0.