### PR TITLE
Rename Particle.from_search/from_search_list to Particle.find/findall

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ you can get a particle directly, or you can use a search:
     >>> Particle.from_pdgid(211)
     <Particle: name='pi+', pdgid=211, mass=139.57061 ± 0.00024 MeV>
     >>>
-    >>> Particle.from_search_list('pi')[0]
+    >>> Particle.findall('pi')[0]
     <Particle: name='pi0', pdgid=111, mass=134.9770 ± 0.0005 MeV>
 
 You can search for the properties using keyword arguments, which include
@@ -143,7 +143,7 @@ set to ``True``/``False``, as well, to limit the search to particles or
 antiparticles.  You can also build the search yourself with the first positional
 argument, which accepts a callable that is given the particle object itself. If
 the first positional argument is a string, that will match against the
-particle's ``name``.  The alternative ``.from_search()`` *requires only one*
+particle's ``name``.  The alternative ``.find()`` *requires only one*
 match returned by the search, and will throw an error if more or less than one
 match is found.
 
@@ -152,26 +152,26 @@ Here are possible sophisticated searches:
 .. code-block:: python
 
     >>> # Print out all particles with asymmetric decay width uncertainties
-    >>> ps = Particle.from_search_list(lambda p: p.width_lower != p.width_upper)
+    >>> ps = Particle.findall(lambda p: p.width_lower != p.width_upper)
     >>> for p in ps:
     ...     print(p.name, p.pdgid, p.width_lower, p.width_upper)
     >>>
     >>> # Find all antiparticles with 'Omega' in the name
-    >>> Particle.from_search_list('Omega', particle=False)   # several found
+    >>> Particle.findall('Omega', particle=False)   # several found
     >>>
     >>> # Find all antiparticles of name=='Omega'
-    >>> Particle.from_search_list(name='Omega', particle=False)  # none found
+    >>> Particle.findall(name='Omega', particle=False)  # none found
     >>>
     >>> # Find all antiparticles of pdgname=='Omega'
-    >>> Particle.from_search_list(pdgname='Omega', particle=False)  # only 1, of course
+    >>> Particle.findall(pdgname='Omega', particle=False)  # only 1, of course
     [<Particle: name='Omega~+', pdgid=-3334, mass=1672.5 ± 0.3 MeV>]
     >>>
     >>> # Find all neutral beauty hadrons
-    >>> Particle.from_search_list(lambda p: p.pdgid.has_bottom and p.charge==0)
+    >>> Particle.findall(lambda p: p.pdgid.has_bottom and p.charge==0)
     >>>
     >>> # Find all strange mesons with c*tau > 1 meter
     >>> from hepunits.units import meter
-    >>> Particle.from_search_list(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.width > 0 and p.ctau > 1 * meter, particle=True)
+    >>> Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.width > 0 and p.ctau > 1 * meter, particle=True)
     [<Particle: name='K(L)0', pdgid=130, mass=497.611 ± 0.013 MeV>,
      <Particle: name='K+', pdgid=321, mass=493.677 ± 0.016 MeV>]
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,7 @@ Version 0.4.0
 Under development
 
 * Changes in API:
+    - Rename ``Particle.from_search/from_search_list`` to ``Particle.find/findall``.
     - Rename ``Particle.fullname/name`` to ``Particle.name/pdgname``.
     - Rename ``Particle.bar`` to ``Particle.is_name_barred``.
     - Rename ``Particle.latex`` to ``Particle.latexname``.

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -439,41 +439,41 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
 
     @classmethod
-    def from_search_list(cls, filter_fn=None, particle=None, **search_terms):
+    def findall(cls, filter_fn=None, particle=None, **search_terms):
         '''
         Search for a particle, returning a list of candidates.
 
         The first and only positional argument is given each particle
         candidate, and returns True/False. Example:
 
-            >>> Particle.from_search_list(lambda p: 'p' in p.name)
+            >>> Particle.findall(lambda p: 'p' in p.name)
             # Returns list of all particles with p somewhere in name
 
         You can pass particle=True/False to force a particle or antiparticle.
         If this is not callable, it will do a "fuzzy" search on the name. So this is identical:
 
-            >>> Particle.from_search_list('p')
+            >>> Particle.findall('p')
             # Returns list of all particles with p somewhere in name
 
         You can also pass keyword arguments, which are either called with the
         matching property if they are callable, or are compared if they are not.
         This would do an exact search on the name, instead of a fuzzy search:
 
-           >>> Particle.from_search_list(name='p')
+           >>> Particle.findall(name='p')
            # Returns proton and antiproton only
 
-           >>> Particle.from_search_list(name='p', particle=True)
+           >>> Particle.findall(name='p', particle=True)
            # Returns proton only
 
         Versatile searches require a (lambda) function as argument:
 
         >>> # Get all neutral beauty hadrons
-        >>> Particle.from_search_list(lambda p: p.pdgid.has_bottom and p.charge==0)
+        >>> Particle.findall(lambda p: p.pdgid.has_bottom and p.charge==0)
         >>>
         >>> # Trivially find all pseudoscalar charm mesons
-        >>> Particle.from_search_list(lambda p: p.pdgid.is_meson and p.pdgid.has_charm and p.spin_type==SpinType.PseudoScalar)
+        >>> Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_charm and p.spin_type==SpinType.PseudoScalar)
 
-        See also ``from_search``, which throws an exception if the particle is not found or too many are found.
+        See also ``find``, which throws an exception if the particle is not found or too many are found.
         '''
 
         # Note that particle can be called by position to keep compatibility with Python 2, but that behavior should
@@ -531,15 +531,15 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         return sorted(results)
 
     @classmethod
-    def from_search(cls, *args, **search_terms):
+    def find(cls, *args, **search_terms):
         '''
         Require that your search returns one and only one result.
         The method otherwise raises a ParticleNotFound or RuntimeError exception.
 
-        See from_search_list for full listing of parameters.
+        See findall for full listing of parameters.
         '''
 
-        results = cls.from_search_list(*args, **search_terms)
+        results = cls.findall(*args, **search_terms)
 
         if len(results) == 1:
             return results[0]
@@ -554,7 +554,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
         mat = getdec.match(name)
         if mat is None:
-            return cls.from_search(name=name)
+            return cls.find(name=name)
         mat = mat.groupdict()
 
         return cls._from_group_dict_list(mat)[0]
@@ -583,7 +583,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
         mat = getname.match(name)
         if mat is None:
-            return cls.from_search_list(name=name, particle=False if bar else None)
+            return cls.findall(name=name, particle=False if bar else None)
         mat = mat.groupdict()
 
         if bar:
@@ -621,12 +621,12 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         else:
             maxname = name
 
-        vals = cls.from_search_list(name = lambda x: maxname in x,
+        vals = cls.findall(name = lambda x: maxname in x,
                                     three_charge=Charge_mapping[mat['charge']],
                                     particle=particle,
                                     J=J)
         if not vals:
-            vals = cls.from_search_list(name = lambda x: name in x,
+            vals = cls.findall(name = lambda x: name in x,
                                         three_charge=Charge_mapping[mat['charge']],
                                         particle=particle,
                                         J=J)

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -19,81 +19,81 @@ from particle.pdgid import PDGID
 from hepunits.units import second
 
 
-def test_from_search():
+def test_find():
     # 1 match found
-    prepr = repr(Particle.from_search(name='gamma'))
+    prepr = repr(Particle.find(name='gamma'))
     assert prepr == "<Particle: name='gamma', pdgid=22, mass=0.0 MeV>"
 
     # No match found
     with pytest.raises(ParticleNotFound):
-        Particle.from_search(name='NonExistent')
+        Particle.find(name='NonExistent')
 
     # Multiple matches found
     with pytest.raises(RuntimeError):
-        Particle.from_search(name=lambda x: 'Upsilon' in x)
+        Particle.find(name=lambda x: 'Upsilon' in x)
 
 
 def test_lambda_style_search():
-    particles = Particle.from_search_list(lambda p: p.pdgname == 'p')
+    particles = Particle.findall(lambda p: p.pdgname == 'p')
     assert len(particles) == 2
     assert 2212 in particles
     assert -2212 in particles
 
-    assert Particle.from_search(lambda p: p.pdgname == 'p' and p > 0) == 2212
-    assert Particle.from_search(lambda p: p.pdgname == 'p' and p < 0) == -2212
+    assert Particle.find(lambda p: p.pdgname == 'p' and p > 0) == 2212
+    assert Particle.find(lambda p: p.pdgname == 'p' and p < 0) == -2212
 
 
 def test_fuzzy_name_search():
-    particles = Particle.from_search_list('p~')
+    particles = Particle.findall('p~')
     assert len(particles) == 1
     assert -2212 in particles
 
 
 def test_keyword_style_search():
-    particles = Particle.from_search_list(pdgname = 'p')
+    particles = Particle.findall(pdgname = 'p')
     assert len(particles) == 2
     assert 2212 in particles
     assert -2212 in particles
 
-    particles = Particle.from_search_list(name = 'p')
+    particles = Particle.findall(name = 'p')
     assert len(particles) == 1
     assert 2212 in particles
 
-    assert Particle.from_search(pdgname = 'p', particle=True) == 2212
-    assert Particle.from_search(pdgname = 'p', particle=False) == -2212
+    assert Particle.find(pdgname = 'p', particle=True) == 2212
+    assert Particle.find(pdgname = 'p', particle=False) == -2212
 
-    assert Particle.from_search(name = 'p', particle=True) == 2212
-    assert Particle.from_search(name = 'p~', particle=False) == -2212
+    assert Particle.find(name = 'p', particle=True) == 2212
+    assert Particle.find(name = 'p~', particle=False) == -2212
 
 
 def test_keyword_lambda_style_search():
-    particles = Particle.from_search_list(pdgname = lambda x: 'p' == x)
+    particles = Particle.findall(pdgname = lambda x: 'p' == x)
     assert len(particles) == 2
     assert 2212 in particles
     assert -2212 in particles
 
     # Fuzzy name
-    particles = Particle.from_search_list(name = lambda x: 'p' in x)
+    particles = Particle.findall(name = lambda x: 'p' in x)
     assert len(particles) > 2
     assert 2212 in particles
     assert -2212 in particles
 
     # Name and particle
-    assert Particle.from_search(name = lambda x: x == 'p', particle=True) == 2212
+    assert Particle.find(name = lambda x: x == 'p', particle=True) == 2212
 
     # Unit based comparison
-    assert 2212 in Particle.from_search_list(lifetime = lambda x : x > 1*second)
+    assert 2212 in Particle.findall(lifetime = lambda x : x > 1*second)
 
 
 def test_complex_search():
     # Find all strange mesons with c*tau > 1 meter
-    particles = Particle.from_search_list(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.width > 0 and p.ctau > 1000., particle=True)
+    particles = Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.width > 0 and p.ctau > 1000., particle=True)
     assert len(particles) == 2 # K+ and KL0
     assert 130 in particles
     assert 321 in particles
 
     # Find all strange anti-mesons with c*tau > 1 meter
-    particles = Particle.from_search_list(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.width > 0 and p.ctau > 1000., particle=False)
+    particles = Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.width > 0 and p.ctau > 1000., particle=False)
     assert len(particles) == 1 # only the K-
     assert -321 in particles
 


### PR DESCRIPTION
Change of API for search methods, as per our discussion.