### PR TITLE
Handling of Particle.empty()

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,7 @@ Under development
 * Neutrinos added to the 2018 data files.
 * Better print-out of particle properties.
 * Better handling of particle names in HTML and LaTeX.
+* Better handling of ``Particle.empty()``.
 * Test suite of ``particle`` and ``pdgid`` submodules improved and extended.
 * More package documentation (data files, ``particle`` and ``pdgid`` submodules).
 * Added utility conversion function of particle names from LaTeX to HTML.

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -160,7 +160,7 @@ class Particle(object):
     # (B (just charge), F (add bar) , and '' (No change))
     quarks = attr.ib('', converter=str)
     status = attr.ib(Status.Nonexistent, converter=Status)
-    latex_name = attr.ib('')
+    latex_name = attr.ib('Unknown')
     mass_upper = attr.ib(0.0)
     mass_lower = attr.ib(0.0)
     width_upper = attr.ib(0.0)
@@ -271,7 +271,7 @@ class Particle(object):
     @property
     def charge(self):
         """The particle charge, in units of the positron charge."""
-        return self.three_charge / 3
+        return self.three_charge / 3 if self.three_charge is not None else None
 
     @property
     def three_charge(self):


### PR DESCRIPTION
Addresses https://github.com/scikit-hep/particle/issues/82.

Now all methods called on `p = Particle.empty()` work just fine. In particular, all name-related methods are consistent.