### PR TITLE
Loading tables is a bit nicer now

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,3 +226,26 @@ the particle:
         SpinType: SpinType.PseudoScalar
         Quarks: dS
         Antiparticle name: K~0 (antiparticle status: Barred)
+
+Advanced: Loading custom tables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can control the particle data tables if you so desire. You can append a new data table using the following syntax:
+
+.. code-block:: python
+
+    >>> from particle import Particle
+    >>> Particle.load_table('new_particles.csv', append=True)
+
+You can also replace the particle table entirely with ``append=False`` (the default).
+
+
+Advanced: Conversion
+^^^^^^^^^^^^^^^^^^^^
+
+You can convert and update the particle tables with the utilities in ``particle.particle.convert``. This requires the
+``pandas`` package, and is only tested with Python 3. Run the following command for more help:
+
+.. code-block:: bash
+
+    $ python3 -m particle.particle.convert --help

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -170,11 +170,26 @@ class Particle(object):
         return "<{self.__class__.__name__}: name='{self!s}', pdgid={pdgid}, mass={mass} MeV>".format(
             self=self, pdgid=int(self.pdgid),
             mass=str_with_unc(self.mass, self.mass_upper, self.mass_lower))
+
     _table = None # Loaded table of entries
     _table_names = None # Names of loaded tables
 
     @classmethod
+    def table_names(cls):
+        """
+        Return the list of names loaded (will load the table, check with table_loaded() first if you don't want to load).
+        """
+
+        if cls._table_names is None:
+            cls.load_table()
+
+        return tuple(cls._table_names) # make a copy to avoid user manipulation
+
+    @classmethod
     def table_loaded(cls):
+        """
+        Check to see if the table is loaded.
+        """
         return not cls._table is None
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,6 @@ import os.path
 from setuptools import setup
 from setuptools import find_packages
 
-test_deps = [
-    'pytest',
-    'pandas',
-]
-
 install_deps = [
     'enum34>=1.1; python_version<"3.4"',
     'importlib_resources>=1.0; python_version<"3.7"',
@@ -25,7 +20,8 @@ install_deps = [
 ]
 
 extras = {
-    'test': test_deps,
+    'test': ['pytest', 'pandas'],
+    'convert': ['pandas'],
 }
 
 def get_version():
@@ -48,7 +44,7 @@ setup(
     package_data={'': ['data/*.*']},
     install_requires = install_deps,
     setup_requires = ['pytest-runner'],
-    tests_require = test_deps,
+    tests_require = extras['test'],
     extras_require = extras,
     keywords = [
         'HEP', 'PDG', 'PDGID', 'particle', 'particle data table',


### PR DESCRIPTION
This PR:

* Makes `load_table(..., append=True)` append to the default table if nothing is loaded; this is consistent with the rest of particle automatically loading the default table if not loaded.
* Adds a history of table names that have been loaded (needs test)
* Adds a bit of documentation (can be expanded)

Partially addresses #102.