### PR TITLE
Produce sdist and wheel

### DIFF
--- a/.ci/azure-wheel.yml
+++ b/.ci/azure-wheel.yml
@@ -1,0 +1,23 @@
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.7'
+    architecture: 'x64'
+
+- script: |
+    python -m pip install --upgrade pip
+    python -m pip install --upgrade setuptools wheel
+  displayName: 'Install dependencies'
+
+- script: |
+    python setup.py sdist
+  displayName: 'Make sdist'
+
+- script: |
+    python setup.py bdist_wheel
+  displayName: 'Make wheel'
+
+- task: PublishPipelineArtifact@0
+  inputs:
+    artifactName: 'artifact'
+    targetPath: 'dist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,3 +50,9 @@ jobs:
 
   steps:
     - template: .ci/azure-steps.yml
+
+- job: 'Package'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: .ci/azure-wheel.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
This adds sdist and universal wheels to the output. Currently only available through Azure's UI, but we could add a release pipeline to publish them on tags.

Note: We could try using the declarative `setup.cfg` instead of `setup.py`, might be interesting to try. https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files 