### PR TITLE
Make particle searches robust against methods returning exceptions

### DIFF
--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -552,7 +552,13 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             # If a filter function is passed, evaluate and skip if False
             if filter_fn is not None:
                 if callable(filter_fn):
-                    if not filter_fn(item):
+                    # Just skip exceptions, which are there for good reasons
+                    # Example: calls to Particle.ctau for particles given
+                    #          default negative, and hence invalid, widths
+                    try:
+                        if not filter_fn(item):
+                            continue
+                    except:
                         continue
                 else:
                     if not(filter_fn in item.name):


### PR DESCRIPTION
This can happen if the particle properties being queried throw exceptions for invalid inputs.

Should fix https://github.com/scikit-hep/particle/pull/123/.