### PR TITLE
Add Binder support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,10 @@ Particle: PDG particle data and identification codes
    :alt: Tests
    :target: https://dev.azure.com/scikit-hep/particle/_build/latest?definitionId=1?branchName=master
 
+.. image:: https://mybinder.org/badge_logo.svg
+   :alt: Binder
+   :target: https://mybinder.org/v2/gh/scikit-hep/particle/master?filepath=notebooks%2FParticleDemo.ipynb
+
 
 Particle provides a pythonic interface to the `Particle Data Group <http://pdg.lbl.gov/>`_ (PDG)
 particle data tables and particle identification codes.

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Particle: PDG particle data and identification codes
 
 .. image:: https://mybinder.org/badge_logo.svg
    :alt: Binder
-   :target: https://mybinder.org/v2/gh/scikit-hep/particle/master?filepath=notebooks%2FParticleDemo.ipynb
+   :target: https://mybinder.org/v2/gh/scikit-hep/particle/master?urlpath=lab/tree/notebooks/ParticleDemo.ipynb
 
 
 Particle provides a pythonic interface to the `Particle Data Group <http://pdg.lbl.gov/>`_ (PDG)

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,2 @@
+pip install --upgrade -r requirements-dev.txt
+pip install --upgrade .

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,0 @@
-pip install --upgrade -r requirements-dev.txt
-pip install --upgrade .

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: particle_demo
+dependencies:
+  - python>=3.7
+  - pandas
+  - attrs
+  - pip
+  - jupyterlab
+  - pip:
+    - hepunits


### PR DESCRIPTION
@henryiii @eduardo-rodrigues It would be great to have the demo be even more interactive by [Binderizing the repo](https://mybinder.org/). 

This PR adds Binder support by installing `particle` from `master` in the [`postBuild` stage](https://mybinder.readthedocs.io/en/latest/config_files.html#postbuild-run-code-after-installing-the-environment). It also installs the `requirements-dev.txt` to make sure that if `pandas` is used in a Notebook it will be available, though as the added Binder badge in the `README` links directly into the demo Jupyter notebook this is more of a safety/future looking addition.

For a demo of what this looks like you can click on this badge which will launch the Binder of my fork: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/particle/feature/add-Binder-support?filepath=notebooks%2FParticleDemo.ipynb)

If accepted I think that this can get squashed, as this is all essentially atomic.

Let me know if you have any questions or requested changes.