### PR TITLE
Examples update to pass doctests

### DIFF
--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -23,6 +23,10 @@ steps:
     python -m pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=particle --cov-report=xml --cov-report=html
   displayName: 'Test with pytest and collect coverage metrics'
 
+- script: |
+    python -m pytest --doctest-modules --ignore-glob="*__main__.py" --ignore-glob="test*"
+  displayName: 'Run doctests'
+
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: '**/test-*.xml'

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -26,6 +26,7 @@ steps:
 - script: |
     python -m pytest --doctest-modules --ignore-glob="*__main__.py" --ignore-glob="test*"
   displayName: 'Run doctests'
+  condition: and(succeeded(), ne(variables['python.version'], '2.7'))
 
 - task: PublishTestResults@2
   inputs:

--- a/particle/particle/convert.py
+++ b/particle/particle/convert.py
@@ -8,11 +8,11 @@ This is a conversion file, not part of the public API.
 
 The default CSV files can be updated directly using the command:
 
-    >>> python -m particle.particle.convert regenerate 2019
+    >>> python -m particle.particle.convert regenerate 2019    # doctest: +SKIP
 
 A custom fwf file and LaTeX file can be converted into the CSV format using:
 
-    >>> python -m particle.particle.convert extended output.csv file.fwf latex.csv
+    >>> python -m particle.particle.convert extended output.csv file.fwf latex.csv    # doctest: +SKIP
 
 This file requires pandas. But most users will not need this file, as it only
 converts PDG data files into the CSV file(s) the public API tools use. The tests
@@ -38,7 +38,7 @@ A utility is even provided to use the modern table to update the full table:
 You can see what particles were missing from the full table if you want:
 
     >>> rem = set(ext_table.index) - set(full_table.index)
-    >>> print(ext_table.loc[rem].sort_index())
+    >>> print(ext_table.loc[rem].sort_index())    # doctest: +SKIP
 
 When you are done, you can save one or more of the tables:
 
@@ -265,7 +265,7 @@ def update_from_mcd(full_table, update_table):
 
     Example
     -------
-    >>> new_table = update_from_mcd('mass_width_2008.fwf', 'mass_width_2019.mcd')
+    >>> new_table = update_from_mcd('mass_width_2008.fwf', 'mass_width_2019.mcd')    # doctest: +SKIP
     """
 
     full_table = full_table.copy()

--- a/particle/particle/kinematics.py
+++ b/particle/particle/kinematics.py
@@ -39,11 +39,11 @@ def width_to_lifetime(Gamma):
 
     >>> from hepunits.units import MeV, eV, ps   # handy module with units in the HEP system of units
     >>>
-    >>> width_to_lifetime(4.33e-10*MeV)
-    0.001520119980246514          # result returned in ns
+    >>> width_to_lifetime(4.33e-10*MeV)   # result returned in ns
+    0.001520119980246514
     >>>
-    >>> width_to_lifetime(4.33e-4*eV)
-    0.001520119980246514          # result again returned in ns
+    >>> width_to_lifetime(4.33e-4*eV)   # result again returned in ns
+    0.001520119980246514
     >>>
     >>> width_to_lifetime(4.33e-10*MeV)/ps   # result converted to ps
     1.520119980246514
@@ -85,11 +85,11 @@ def lifetime_to_width(tau):
 
     >>> from hepunits.units import MeV, eV, ps   # handy module with units in the HEP system of units
     >>>
-    >>> lifetime_to_width(0.001520119980246514*ns)
-    4.33e-10          # result returned in MeV
+    >>> lifetime_to_width(0.001520119980246514*ns)   # result returned in MeV
+    4.33e-10
     >>>
-    >>> lifetime_to_width(1.520119980246514*ps)
-    4.33e-10          # result again returned in MeV
+    >>> lifetime_to_width(1.520119980246514*ps)   # result again returned in MeV
+    4.33e-10
     >>>
     >>> lifetime_to_width(1.520119980246514*ps)/eV   # result converted to eV
     0.000433

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -507,32 +507,32 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         The first and only positional argument is given each particle
         candidate, and returns True/False. Example:
 
-            >>> Particle.findall(lambda p: 'p' in p.name)
+            >>> Particle.findall(lambda p: 'p' in p.name)    # doctest: +SKIP
             # Returns list of all particles with p somewhere in name
 
         You can pass particle=True/False to force a particle or antiparticle.
         If this is not callable, it will do a "fuzzy" search on the name. So this is identical:
 
-            >>> Particle.findall('p')
+            >>> Particle.findall('p')    # doctest: +SKIP
             # Returns list of all particles with p somewhere in name
 
         You can also pass keyword arguments, which are either called with the
         matching property if they are callable, or are compared if they are not.
         This would do an exact search on the name, instead of a fuzzy search:
 
-           >>> Particle.findall(name='p')
-           # Returns proton and antiproton only
+           >>> Particle.findall(pdg_name='p')  # Returns proton and antiproton only
+           [<Particle: name="p", pdgid=2212, mass=938.272081 ± 0.000006 MeV>, <Particle: name="p~", pdgid=-2212, mass=938.272081 ± 0.000006 MeV>]
 
-           >>> Particle.findall(name='p', particle=True)
-           # Returns proton only
+           >>> Particle.findall(pdg_name='p', particle=True)  # Returns proton only
+           [<Particle: name="p", pdgid=2212, mass=938.272081 ± 0.000006 MeV>]
 
         Versatile searches require a (lambda) function as argument:
 
         >>> # Get all neutral beauty hadrons
-        >>> Particle.findall(lambda p: p.pdgid.has_bottom and p.charge==0)
+        >>> Particle.findall(lambda p: p.pdgid.has_bottom and p.charge==0)    # doctest: +SKIP
         >>>
         >>> # Trivially find all pseudoscalar charm mesons
-        >>> Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_charm and p.spin_type==SpinType.PseudoScalar)
+        >>> Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_charm and p.spin_type==SpinType.PseudoScalar)  # doctest: +SKIP
 
         See also ``find``, which throws an exception if the particle is not found or too many are found.
         '''


### PR DESCRIPTION
Addresses most of https://github.com/scikit-hep/particle/issues/108. What remains to be done is an update of the CI so that doctests are run by default. @henryiii, what would be the best way?

For the record I ran doctests on all but the `test` directories and `__main__.py` with the command
`pytest --doctest-modules --ignore-glob="*__main__.py" --ignore-glob="test*"`.