### PR TITLE
Rename Particle.from_dec to Particle.from_evtgen_name and use converters

### DIFF
--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -592,6 +592,11 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         return val
 
     @property
+    def evtgen_name(self):
+        'This is the name used in EvtGen.'
+        return EvtGenName2PDGIDBiMap[self.pdgid]
+
+    @property
     def programmatic_name(self):
         'This name could be used for a variable name.'
         return programmatic_name(self.name)

--- a/tests/particle/test_decfilenames.py
+++ b/tests/particle/test_decfilenames.py
@@ -616,10 +616,13 @@ list_dec_but_not_in_pdt = [
  'Sigma_b0',
  'Upsilon_1(1D)',
  'Upsilon_1(2D)',
+ 'Upsilon_2(1D)',
  'Upsilon_2(2D)',
  'Upsilon_3(1D)',
  'Upsilon_3(2D)',
  'X_1(3872)',
+ "Xi'_b-",
+ "Xi'_b0",
  'Xi_b*-',
  'Xi_b*0',
  'Xi_bc+',
@@ -649,6 +652,8 @@ list_dec_but_not_in_pdt = [
  'anti-Omega_cc-',
  'anti-Sigma_b*0',
  'anti-Sigma_b0',
+ "anti-Xi'_b0",
+ "anti-Xi'_b+",
  'anti-Xi_b*+',
  'anti-Xi_b*0',
  'anti-Xi_bc-',
@@ -665,6 +670,7 @@ list_dec_but_not_in_pdt = [
  'eta_b2(2D)',
  'h_b(2P)',
  'h_b(3P)',
+ 'omega(2S)',
  'rho(3S)+',
  'rho(3S)-',
  'rho(3S)0'
@@ -723,26 +729,7 @@ list_dec_specific = [
 
 # Sub-list of particle names that Particle.from_dec has trouble with at present
 # Consider this as a TODO
-list_undealt_with = [
- "D'_s1+",
- "D'_s1-",
- "K''*+",
- "K''*-",
- "K''*0",
- "K'*+",
- "K'*-",
- "K'*0",
- "K'_1+",
- "K'_1-",
- "K'_10",
- "Xi'_b-",
- "Xi'_b0",
- "anti-K''*0",
- "anti-K'*0",
- "anti-K'_10",
- "anti-Xi'_b+",
- "anti-Xi'_b0"
-]
+list_undealt_with = []
 
 for elm in list_dec_but_not_in_pdt+list_dec_specific:
     dec_names.remove(elm)

--- a/tests/particle/test_decfilenames.py
+++ b/tests/particle/test_decfilenames.py
@@ -727,10 +727,6 @@ list_dec_specific = [
  'specflav'
  ]
 
-# Sub-list of particle names that Particle.from_dec has trouble with at present
-# Consider this as a TODO
-list_undealt_with = []
-
 for elm in list_dec_but_not_in_pdt+list_dec_specific:
     dec_names.remove(elm)
 
@@ -743,4 +739,4 @@ def test_decfile_style_names_valid():
         except ParticleNotFound:
             failures.add(name)
 
-    assert failures == set(list_undealt_with)
+    assert failures == set()

--- a/tests/particle/test_decfilenames.py
+++ b/tests/particle/test_decfilenames.py
@@ -752,7 +752,7 @@ def test_decfile_style_names_valid():
     failures = set()
     for name in dec_names:
         try:
-            assert Particle.from_dec(name).pdgid != 0
+            assert Particle.from_evtgen_name(name).pdgid != 0
         except ParticleNotFound:
             failures.add(name)
 

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -469,4 +469,4 @@ decfile_style_names = (
 
 @pytest.mark.parametrize("name,pid", decfile_style_names)
 def test_decfile_style_names(name, pid):
-    assert Particle.from_dec(name).pdgid == pid
+    assert Particle.from_evtgen_name(name).pdgid == pid

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -433,7 +433,6 @@ decfile_style_names = (
     ("rho+", 213),
     ("rho(2S)0", 100113),
     ("omega", 223),
-    ("omega(2S)", 1000223),
     ("omega(1650)", 30223),
     ("Delta++", 2224),
     ("Delta+", 2214),


### PR DESCRIPTION
This greatly simplifies the good-old `Particle.from_dec(...)` method, now that we have converters in the package. It seems natural to rename the method to `Particle.from_evtgen_name` to follow the conventions of the other `_name` properties and methods.