### PR TITLE
Allow CSV files to have comments starting with #

### DIFF
--- a/particle/converters/bimap.py
+++ b/particle/converters/bimap.py
@@ -72,10 +72,12 @@ class BiMap(object):
 
         with filename as _f:
             self._to_map = {converters[1](v[name_B]):converters[0](v[name_A])
-                            for v in csv.DictReader(_f)}
+                            for v in csv.DictReader(l for l in _f
+                                                    if not l.startswith('#'))}
             _f.seek(0)
             self._from_map = {converters[0](v[name_A]):converters[1](v[name_B])
-                              for v in csv.DictReader(_f)}
+                              for v in csv.DictReader(l for l in _f
+                                                    if not l.startswith('#'))}
 
     def __getitem__(self, value):
         if isinstance(value, self.class_B):
@@ -148,12 +150,12 @@ def DirectionalMaps(name_A, name_B, converters=(str, str), filename=None):
 
         with filename as _f:
             to_map = {converters[1](v[name_B]):converters[0](v[name_A])
-                      for v in csv.DictReader(_f,
+                      for v in csv.DictReader((l for l in _f if not l.startswith('#')),
                                               fieldnames=fieldnames,
                                               skipinitialspace=skipinitialspace)}
             _f.seek(0)
             from_map = {converters[0](v[name_A]):converters[1](v[name_B])
-                        for v in csv.DictReader(_f,
+                        for v in csv.DictReader((l for l in _f if not l.startswith('#')),
                                                 fieldnames=fieldnames,
                                                 skipinitialspace=skipinitialspace)}
 

--- a/particle/geant/geantid.py
+++ b/particle/geant/geantid.py
@@ -17,7 +17,8 @@ from ..exceptions import MatchingIDNotFound
 
 
 with data.open_text(data, 'pdgid_to_geantid.csv') as _f:
-    _bimap = {int(v['GEANTID']):int(v['PDGID']) for v in csv.DictReader(_f)}
+    _bimap = {int(v['GEANTID']):int(v['PDGID']) for v in csv.DictReader(
+        l for l in _f if not l.startswith('#'))}
 
 
 class GeantID(int):

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -351,7 +351,7 @@ class Particle(object):
             cls._table_names.append('{0!r} {1}'.format(filename, len(cls._table_names)))
 
         with filename as f:
-            r = csv.DictReader(f)
+            r = csv.DictReader(l for l in f if not l.startswith('#'))
 
             for v in r:
                 value = int(v['ID'])

--- a/particle/pythia/pythiaid.py
+++ b/particle/pythia/pythiaid.py
@@ -17,7 +17,8 @@ from ..exceptions import MatchingIDNotFound
 
 
 with data.open_text(data, 'pdgid_to_pythiaid.csv') as _f:
-    _bimap = {int(v['PYTHIAID']):int(v['PDGID']) for v in csv.DictReader(_f)}
+    _bimap = {int(v['PYTHIAID']):int(v['PDGID']) for v in csv.DictReader(
+        l for l in _f if not l.startswith('#'))}
 
 
 class PythiaID(int):


### PR DESCRIPTION
This is a straightforward patch to allow CSV to have comments.

A nicer approach which I can of course also quickly implement is to create a wrapper function for `csv.DictReader`.

The aim is to allow version information or other comments to be added to the CSV files.