### PR TITLE
Remove non-robust C and P properties in PDGID

### DIFF
--- a/particle/pdgid/__init__.py
+++ b/particle/pdgid/__init__.py
@@ -95,8 +95,6 @@ from .functions import s_spin
 from .functions import S
 from .functions import l_spin
 from .functions import L
-from .functions import P
-from .functions import C
 from .functions import A
 from .functions import Z
 

--- a/particle/pdgid/functions.py
+++ b/particle/pdgid/functions.py
@@ -448,43 +448,6 @@ def l_spin(pdgid):
     return (2*value+1) if value is not None else value
 
 
-def P(pdgid):
-    """
-    Returns the parity quantum number P = (-1)^(L+1).
-
-    Notes
-    -----
-    - This is valid for mesons only. None is returned otherwise.
-    - Mesons with PDGIDs of the kind 9XXXXXX (N=9) are not experimentally well-known particles
-      and None is returned too.
-    """
-    if not is_meson(pdgid): return None
-    if not is_valid(pdgid): return None
-
-    # At this stage it is guaranteed that L != None
-    return (-1)**(L(pdgid)+1) if L(pdgid) is not None else None
-
-
-def C(pdgid):
-    """
-    Returns the charge conjugation quantum number C = (-1)^(L+S).
-
-    Notes
-    -----
-    - This is valid for mesons only. None is returned otherwise.
-    - Mesons with PDGIDs of the kind 9XXXXXX (N=9) are not experimentally well-known particles
-      and None is returned too.
-    """
-    if not is_meson(pdgid) or not three_charge(pdgid) == 0: return None
-    if not is_valid(pdgid): return None
-
-    if L(pdgid) is None or S(pdgid) is None:
-        return None
-
-    # At this stage it is guaranteed that L and S != None
-    return (-1)**(L(pdgid)+S(pdgid))
-
-
 def A(pdgid):
     """Returns the atomic number A if the PDG ID corresponds to a nucleus. Else it returns None."""
     # A proton can also be a Hydrogen nucleus
@@ -532,7 +495,11 @@ def _fundamental_id(pdgid):
 
 
 def _has_quark_q(pdgid, q):
-    """Helper function - does this particle contain a quark q?"""
+    """
+    Helper function - does this particle contain a quark q?
+
+    Note that q is always positive, so [1, 6] for Standard Model quarks.
+    """
     if _extra_bits(pdgid) > 0 : return False
     if _fundamental_id(pdgid) > 0 : return False
     if is_dyon(pdgid): return False

--- a/tests/pdgid/test_functions.py
+++ b/tests/pdgid/test_functions.py
@@ -34,8 +34,6 @@ from particle.pdgid import S
 from particle.pdgid import s_spin
 from particle.pdgid import L
 from particle.pdgid import l_spin
-from particle.pdgid import P
-from particle.pdgid import C
 from particle.pdgid import A
 from particle.pdgid import Z
 
@@ -422,54 +420,7 @@ def test_L_non_mesons(PDGIDs):
     _L_eq_None= (PDGIDs.Gluon, PDGIDs.Photon, PDGIDs.Z0)
     for id in _L_eq_None: assert L(id) == None
 
-
-def test_PC_mesons(PDGIDs):
-# List of pairs (P, C) for a list of PDG IDs
-    list_PC_pairs = (
-        (PDGIDs.Pi0, -1, +1),
-        (PDGIDs.PiPlus, -1, None),
-        (PDGIDs.eta, -1, +1),
-        (PDGIDs.eta_prime, -1, +1),
-        (PDGIDs.KL, -1, +1),
-        (PDGIDs.KS, -1, +1),
-        (PDGIDs.KMinus, -1, None),
-        (PDGIDs.D0, -1, +1),
-        (PDGIDs.DPlus, -1, None),
-        (PDGIDs.DsPlus, -1, None),
-        (PDGIDs.B0, -1, +1),
-        (PDGIDs.BPlus, -1, None),
-        (PDGIDs.Bs, -1, +1),
-        (PDGIDs.BcPlus, -1, None),
-        (PDGIDs.T0, -1, +1),
-        (PDGIDs.a_0_1450_plus, +1, None),
-        (PDGIDs.K1_1270_0, +1, -1),
-        (PDGIDs.rho_770_minus, -1, None),
-        (PDGIDs.K1_1400_0, +1, +1),
-        (PDGIDs.K1_1400_0, +1, +1),
-        (PDGIDs.rho_1700_0, -1, -1),
-        (PDGIDs.a2_1320_minus, +1, None),
-        (PDGIDs.omega_3_1670, -1, -1)
-        )
-    for trio in list_PC_pairs:
-        assert P(trio[0]) == trio[1]
-        assert C(trio[0]) == trio[2]
-
-
-def test_PC_badly_known_mesons(PDGIDs):
-    assert P(PDGIDs.f_4_2300) == None
-    assert C(PDGIDs.f_4_2300) == None
-
-
-def test_P_non_mesons(PDGIDs):
-    _non_mesons = (PDGIDs.Gluon, PDGIDs.Photon, PDGIDs.Z0)
-    for id in _non_mesons: assert C(id) == None
-
-
-def test_C_non_mesons(PDGIDs):
-    _non_mesons = (PDGIDs.Gluon, PDGIDs.Photon, PDGIDs.Z0)
-    for id in _non_mesons: assert C(id) == None
-
-
+    
 def test_A(PDGIDs):
     _nuclei = { PDGIDs.Proton: 1,
                 PDGIDs.HydrogenNucleus: 1,

--- a/tests/pdgid/test_pdgid.py
+++ b/tests/pdgid/test_pdgid.py
@@ -43,10 +43,8 @@ def test_nonphysical_pdgids():
 
 def test_info():
     __info = """A              None
-C              None
 J              1.0
 L              None
-P              None
 S              None
 Z              None
 abspid         22


### PR DESCRIPTION
It turns out that the information stored in a PDG ID is *not* enough to calculate the `C` and `P` quantum numbers. Indeed, for example, `C` is only valid for *unflavoured* mesons and flavourness is not something determinable from the PDG ID.

These quantum numbers are of course available in the `Particle` class, as PDG data, so no worries.