### PR TITLE
Make Particle.dump_table() work better in notebooks

### DIFF
--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -293,16 +293,20 @@ class Particle(object):
             Column alignment for numbers, see the tabulate's package
             tabulate function for a description of available options.
 
+        Returns
+        -------
+        str or None if filename is None or not, respectively.
+
         Note
         ----
         Uses the `tabulate` package.
 
         Examples
         --------
-        Particle.dump_table()
-        Particle.dump_table(n_rows=5)
-        Particle.dump_table(exclusive_fields=['pdgid', 'pdg_name'])
-        Particle.dump_table(filter_fn=lambda p: p.pdgid.has_bottom)
+        print(Particle.dump_table())
+        print(Particle.dump_table(n_rows=5))
+        print(Particle.dump_table(exclusive_fields=['pdgid', 'pdg_name']))
+        print(Particle.dump_table(filter_fn=lambda p: p.pdgid.has_bottom))
         Particle.dump_table(filename='output.txt', tablefmt='rst')
         """
         from tabulate import tabulate
@@ -349,19 +353,17 @@ class Particle(object):
                         headers=tbl_names,
                         tablefmt=tablefmt,
                         floatfmt=floatfmt,
-                        numalign=numalign,
+                        numalign=numalign
                     ),
                     file=outfile,
                 )
         else:
-            print(
-                tabulate(
-                    tbl,
-                    headers=tbl_names,
-                    tablefmt=tablefmt,
-                    floatfmt=floatfmt,
-                    numalign=numalign,
-                )
+            return tabulate(
+                tbl,
+                headers=tbl_names,
+                tablefmt=tablefmt,
+                floatfmt=floatfmt,
+                numalign=numalign
             )
 
     @classmethod

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -353,7 +353,7 @@ class Particle(object):
                         headers=tbl_names,
                         tablefmt=tablefmt,
                         floatfmt=floatfmt,
-                        numalign=numalign
+                        numalign=numalign,
                     ),
                     file=outfile,
                 )
@@ -363,7 +363,7 @@ class Particle(object):
                 headers=tbl_names,
                 tablefmt=tablefmt,
                 floatfmt=floatfmt,
-                numalign=numalign
+                numalign=numalign,
             )
 
     @classmethod


### PR DESCRIPTION
This way code such as
```
from IPython.display import HTML
HTML(Particle.dump_table(filter_fn=lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.ctau > 1 * meter, exclusive_fields=['pdgid', 'pdg_name', 'html_name'], tablefmt='html'))
```
works nicely.