### PR TITLE
Deal with particles with no mass info

### DIFF
--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -189,9 +189,7 @@ class Particle(object):
 
     def __repr__(self):
         return '<{self.__class__.__name__}: name="{self!s}", pdgid={pdgid}, mass={mass}>'.format(
-            self=self,
-            pdgid=int(self.pdgid),
-            mass=self._safe_mass(),
+            self=self, pdgid=int(self.pdgid), mass=self._safe_mass()
         )
 
     _table = None  # Loaded table of entries
@@ -696,7 +694,9 @@ class Particle(object):
         if self.mass is None:
             return "?"
         else:
-            return "{0} MeV".format(str_with_unc(self.mass, self.mass_upper, self.mass_lower))
+            return "{0} MeV".format(
+                str_with_unc(self.mass, self.mass_upper, self.mass_lower)
+            )
 
     def describe(self):
         "Make a nice high-density string for a particle's properties."

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -189,7 +189,7 @@ class Particle(object):
 
     def __repr__(self):
         return '<{self.__class__.__name__}: name="{self!s}", pdgid={pdgid}, mass={mass}>'.format(
-            self=self, pdgid=int(self.pdgid), mass=self._safe_mass()
+            self=self, pdgid=int(self.pdgid), mass=self._str_mass()
         )
 
     _table = None  # Loaded table of entries
@@ -685,7 +685,7 @@ class Particle(object):
                 width=str_with_unc(self.width, self.width_upper, self.width_lower)
             )
 
-    def _safe_mass(self):
+    def _str_mass(self):
         """
         Display a reasonable particle mass printout
         even when no mass value is available.
@@ -714,7 +714,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             C=Parity_undo[self.C],
             Q=Charge_undo[self.three_charge],
             P=Parity_undo[self.P],
-            mass=self._safe_mass(),
+            mass=self._str_mass(),
             width_or_lifetime=self._width_or_lifetime(),
             latex_name=self._repr_latex_(),
         )

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -483,8 +483,10 @@ def test_isospin(pid, isospin):
 def test_default_particle():
     p = Particle.empty()
 
-    assert repr(p) == '<Particle: name="Unknown", pdgid=0, mass=0.0 MeV>'
+    assert repr(p) == '<Particle: name="Unknown", pdgid=0, mass=?>'
     assert "Name: Unknown" in p.describe()
+    assert p.mass == None
+    assert p.width == None
     assert p.spin_type == SpinType.NonDefined
     assert p.programmatic_name == "Unknown"
     assert p.status == Status.Nonexistent


### PR DESCRIPTION
This is relevant to deal e.g. with diquarks.

While at it, the `Particle.empty()` dummy particle got fixed as well, since the definition was not completely what one would expect - it should provide no mass/width info.