### PR TITLE
fixes collections.abc deprecation warning

### DIFF
--- a/particle/converters/bimap.py
+++ b/particle/converters/bimap.py
@@ -5,7 +5,12 @@
 
 from __future__ import absolute_import
 
-from collections.abc import Mapping
+try:
+    # for Python 3
+    from collections.abc import Mapping
+except ImportError:
+    # for Python 2.7
+    from collections import Mapping
 
 import csv
 

--- a/particle/converters/bimap.py
+++ b/particle/converters/bimap.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import
 
-from collections import Mapping
+from collections.abc import Mapping
 
 import csv
 


### PR DESCRIPTION
Fixes
```
particle/converters/bimap.py:8
  /Users/hdembinski/Extern/particle/particle/converters/bimap.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```