### PR TITLE
Missing and non-relevant particle properties - print-outs made more consistent

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,7 @@ In preparation.
   - Several improvements, in particular to better deal with nuclei and diquarks.
   - Speed of table loading improved.
   - Particle enums extended for diquarks.
+  - Print-outs made more consistent for missing and non-relevant particle properties.
   - New tests added.
 * ``PDGID`` class:
   - PDG ID functions extended to correctly and consistently deal with nuclei.

--- a/particle/particle/enums.py
+++ b/particle/particle/enums.py
@@ -143,7 +143,7 @@ Status_mapping = {
 }
 
 # Mappings that allow the above classes to be turned into text mappings
-Parity_undo = {Parity.p: "+", Parity.o: "0", Parity.m: "-", Parity.u: "?"}
+Parity_undo = {Parity.p: "+", Parity.o: "0", Parity.m: "-", Parity.u: "None"}
 Parity_prog = {Parity.p: "p", Parity.o: "0", Parity.m: "m", Parity.u: "u"}
 
 Charge_undo = {
@@ -158,7 +158,7 @@ Charge_undo = {
     Charge.m: "-",
     Charge.m43: "-4/3",
     Charge.mm: "--",
-    Charge.u: "?",
+    Charge.u: "None",
 }
 Charge_prog = {
     Charge.pp: "pp",

--- a/particle/particle/particle.py
+++ b/particle/particle/particle.py
@@ -628,7 +628,7 @@ class Particle(object):
         Width errors equal to None flag an experimental upper limit on the width.
         """
         if self.width is None:
-            return "Width = ?"
+            return "Width = None"
         elif self.width == 0:
             return "Width = 0.0 MeV"
         elif self.width_lower is None and self.width_upper is None:
@@ -727,7 +727,7 @@ class Particle(object):
         Internally used by the describe() method.
         """
         if self.mass is None:
-            return "?"
+            return "None"
         else:
             return "{0} MeV".format(
                 str_with_unc(self.mass, self.mass_upper, self.mass_lower)

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -276,7 +276,7 @@ def test_C_consistency():
 
 checklist_describe = (
     # Test undefined width value
-    [1, "Width = ?"],  # d quark
+    [1, "Width = None"],  # d quark
     # Test print-out of zero width values
     [22, "Width = 0.0 MeV"],  # photon
     # Test print-out of symmetric width errors
@@ -506,7 +506,7 @@ def test_isospin(pid, isospin):
 def test_default_particle():
     p = Particle.empty()
 
-    assert repr(p) == '<Particle: name="Unknown", pdgid=0, mass=?>'
+    assert repr(p) == '<Particle: name="Unknown", pdgid=0, mass=None>'
     assert "Name: Unknown" in p.describe()
     assert p.mass == None
     assert p.width == None


### PR DESCRIPTION
First stab at this, as per our discussions, @HDembinski and @henryiii.