### PR TITLE
Make particle literals available from top-level import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -217,11 +217,11 @@ with easily recognisable names. For example:
 
 .. code-block:: python
 
-    >>> from particle.particle import literals as lp
+    >>> from particle import literals as lp
     >>> lp.pi_plus
     <Particle: name="pi+", pdgid=211, mass=139.57061 ± 0.00024 MeV>
     >>>
-    >>> from particle.particle.literals import Lambda_b_0
+    >>> from particle.literals import Lambda_b_0
     >>> Lambda_b_0
     <Particle: name="Lambda(b)0", pdgid=5122, mass=5619.60 ± 0.17 MeV>
     >>> Lambda_b_0.J

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,7 @@ In preparation.
   - Several improvements, in particular to better deal with nuclei and diquarks.
   - Speed of table loading improved.
   - Particle enums extended for diquarks.
+  - Make particle literals available from top-level import.
   - Print-outs made more consistent for missing and non-relevant particle properties.
   - New tests added.
 * ``PDGID`` class:
@@ -20,7 +21,7 @@ In preparation.
     - A couple of PDG ID numbers corrected (they had evolved in time).
   - Converter script adapted to add to the produced data files
     particles not in the PDG data table, such as diquarks.
-* Redesigned packaging system
+* Redesigned packaging system.
 * Miscellaneous:
   - Files ``*requirements.txt`` removed from package - use ``pip install .[dev]`` instead
   - Warning from ``collections.abc`` fixed, keeping compatibility with Python 2.

--- a/notebooks/ParticleDemo.ipynb
+++ b/notebooks/ParticleDemo.ipynb
@@ -279,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import particle.particle.literals as particle_literals"
+    "import particle.literals as particle_literals"
    ]
   },
   {

--- a/src/particle/__init__.py
+++ b/src/particle/__init__.py
@@ -21,7 +21,8 @@ from .particle import ParticleNotFound, InvalidParticle
 
 # Direct access to Particle literals
 from .particle import literals
-sys.modules['particle.literals'] = literals
+
+sys.modules["particle.literals"] = literals
 
 # Direct access to kinematics functions
 from .particle import width_to_lifetime, lifetime_to_width

--- a/src/particle/__init__.py
+++ b/src/particle/__init__.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+import sys
+
 # Convenient access to the version number
 from .version import version as __version__
 
@@ -16,7 +18,10 @@ from .pythia import PythiaID
 # Direct access to Particle (the CSV file is not read until a particle is accessed)
 from .particle import Particle, SpinType, Parity, Charge, Inv, Status
 from .particle import ParticleNotFound, InvalidParticle
+
+# Direct access to Particle literals
 from .particle import literals
+sys.modules['particle.literals'] = literals
 
 # Direct access to kinematics functions
 from .particle import width_to_lifetime, lifetime_to_width

--- a/src/particle/__init__.py
+++ b/src/particle/__init__.py
@@ -16,6 +16,7 @@ from .pythia import PythiaID
 # Direct access to Particle (the CSV file is not read until a particle is accessed)
 from .particle import Particle, SpinType, Parity, Charge, Inv, Status
 from .particle import ParticleNotFound, InvalidParticle
+from .particle import literals
 
 # Direct access to kinematics functions
 from .particle import width_to_lifetime, lifetime_to_width

--- a/src/particle/particle/literals.py
+++ b/src/particle/particle/literals.py
@@ -13,12 +13,12 @@ The aliases are instances of the Particle class.
 
 Typical use cases::
 
-    >>> from particle.particle import literals as lp
+    >>> from particle import literals as lp
     >>> lp.pi_plus
     <Particle: name="pi+", pdgid=211, mass=139.57061 ± 0.00024 MeV>
     >>> lp.pi_plus.name
     'pi+'
-    >>> from particle.particle.literals import Lambda_b_0
+    >>> from particle.literals import Lambda_b_0
     >>> Lambda_b_0
     <Particle: name="Lambda(b)0", pdgid=5122, mass=5619.60 ± 0.17 MeV>
     >>> Lambda_b_0.J

--- a/tests/particle/test_literals.py
+++ b/tests/particle/test_literals.py
@@ -7,7 +7,7 @@ from __future__ import division
 
 import pytest
 
-from particle.particle import literals as lp
+from particle import literals as lp
 
 
 def test_literals_import():


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/particle/issues/238.