### PR TITLE
New functions for qualification of PDG IDs

### DIFF
--- a/src/particle/pdgid/__init__.py
+++ b/src/particle/pdgid/__init__.py
@@ -72,13 +72,17 @@ from .functions import is_lepton
 from .functions import is_hadron
 from .functions import is_meson
 from .functions import is_baryon
-from .functions import is_diquark
-from .functions import is_nucleus
 from .functions import is_pentaquark
+from .functions import is_sm_gauge_boson_or_higgs
+from .functions import is_generator_specific
+from .functions import is_nucleus
+from .functions import is_diquark
 from .functions import is_Rhadron
 from .functions import is_Qball
 from .functions import is_dyon
 from .functions import is_SUSY
+from .functions import is_technicolor
+from .functions import is_composite_quark_or_lepton
 
 from .functions import has_down
 from .functions import has_up

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -252,6 +252,26 @@ def is_pentaquark(pdgid):
     return True
 
 
+def is_sm_gauge_boson_or_higgs(pdgid):
+    # type: (PDGID_TYPE) -> bool
+    """
+    Does this PDG ID correspond to a Standard Model gauge boson or Higgs?
+
+    Codes 21-30 are reserved for the Standard Model gauge bosons and the Higgs.
+    """
+    return True if pdgid in range(21, 31) else False
+
+
+def is_generator_specific(pdgid):
+    # type: (PDGID_TYPE) -> bool
+    """
+    Does this PDG ID correspond to generator-specific pseudoparticles or concepts?
+
+    Codes 81-100 are reserved for this purpose.
+    """
+    return True if pdgid in range(81, 101) else False
+
+
 def is_Rhadron(pdgid):
     # type: (PDGID_TYPE) -> bool
     """Does this PDG ID correspond to an R-hadron?
@@ -340,6 +360,34 @@ def is_SUSY(pdgid):
     if _digit(pdgid, Location.Nr) != 0:
         return False
     if _fundamental_id(pdgid) == 0:
+        return False
+    return True
+
+
+def is_technicolor(pdgid):
+    # type: (PDGID_TYPE) -> bool
+    """
+    Does this PDG ID correspond to a Technicolor state?
+
+    Technicolor states have N = 3.
+    """
+    if _extra_bits(pdgid) > 0:
+        return False
+    return True if _digit(pdgid, Location.N) == 3 else False
+
+
+def is_composite_quark_or_lepton(pdgid):
+    # type: (PDGID_TYPE) -> bool
+    """
+    Does this PDG ID correspond to an excited (composite) quark or lepton?
+
+    Excited (composite) quarks and leptons have N = 4 and Nr = 0.
+    """
+    if _extra_bits(pdgid) > 0:
+        return False
+    if _fundamental_id(pdgid) == 0:
+        return False
+    if not (_digit(pdgid, Location.N) == 4 and _digit(pdgid, Location.Nr) == 0):
         return False
     return True
 

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -279,7 +279,7 @@ def is_generator_specific(pdgid):
 
     Codes 81-100 are reserved for this purpose.
     """
-    return True if pdgid in range(81, 101) else False
+    return True if abspid(pdgid) in range(81, 101) else False
 
 
 def is_Rhadron(pdgid):

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -69,6 +69,14 @@ def is_valid(pdgid):
         return True
     if is_pentaquark(pdgid):
         return True
+    if is_sm_gauge_boson_or_higgs(pdgid):
+        return True
+    if is_generator_specific(pdgid):
+        return True
+    if is_technicolor(pdgid):
+        return True
+    if is_composite_quark_or_lepton(pdgid):
+        return True
     if _extra_bits(pdgid) > 0:
         if is_nucleus(pdgid):
             return True
@@ -259,6 +267,8 @@ def is_sm_gauge_boson_or_higgs(pdgid):
 
     Codes 21-30 are reserved for the Standard Model gauge bosons and the Higgs.
     """
+    if abspid(pdgid) == 24:  # W is the only SM gauge boson not its antiparticle
+        return True
     return True if pdgid in range(21, 31) else False
 
 

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -277,9 +277,27 @@ def is_generator_specific(pdgid):
     """
     Does this PDG ID correspond to generator-specific pseudoparticles or concepts?
 
-    Codes 81-100 are reserved for this purpose.
+    Codes 81-100 are reserved for generator-specific pseudoparticles and concepts.
+    Codes 901-930, 1901-1930, 2901-2930, and 3901-3930 are for
+    additional components of Standard Model parton distribution functions,
+    where the latter three ranges are intended to distinguish
+    left/right/longitudinal components.
+    Codes 998 and 999 are reserved for GEANT tracking purposes.
     """
-    return True if abspid(pdgid) in range(81, 101) else False
+    aid = abspid(pdgid)
+    if aid in range(81, 101):
+        return True
+    if aid in range(901, 931):
+        return True
+    if aid in range(1901, 1931):
+        return True
+    if aid in range(2901, 2931):
+        return True
+    if aid in range(3901, 3931):
+        return True
+    if aid in (998, 999):
+        return True
+    return False
 
 
 def is_Rhadron(pdgid):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,10 +112,17 @@ class PDGIDsEnum(IntEnum):
     HydrogenNucleus = 1000010010
     Carbon12 = 1000060120
     # Pentaquarks
-    UCbarCUDPentaquark = (
-        9422144  # example of spin 3/2 u-cbar-c-u-d pentaquark decaying to J/psi proton
-    )
     AntiUCbarCUDPentaquark = -9422144
+    # example of spin 3/2 u-cbar-c-u-d pentaquark decaying to J/psi proton
+    UCbarCUDPentaquark = 9422144
+    # Technicolor
+    Pi0TC = 3000111
+    PiMinusTC = -3000211
+    # Composite quarks and leptons
+    UQuarkStar = 4000002
+    AntiElectronStar = -4000011
+    # Generator specific pseudoparticles or concepts
+    AntiCHadron = -84
     # Invalid ID
     Invalid1 = 0  # illegal ID
     Invalid2 = 99999999  # general form is a 7-digit number

--- a/tests/pdgid/test_functions.py
+++ b/tests/pdgid/test_functions.py
@@ -215,7 +215,7 @@ def test_is_sm_gauge_boson_or_higgs(PDGIDs):
         PDGIDs.Photon,
         PDGIDs.Z0,
         PDGIDs.WMinus,
-        PDGIDs.HiggsBoson
+        PDGIDs.HiggsBoson,
     )
     _non_sm_gb_and_higgs = [id for id in PDGIDs if id not in _sm_gb_and_higgs]
     for id in _sm_gb_and_higgs:
@@ -225,7 +225,7 @@ def test_is_sm_gauge_boson_or_higgs(PDGIDs):
 
 
 def test_is_generator_specific(PDGIDs):
-    _generator_specific = (PDGIDs.AntiCHadron)
+    _generator_specific = PDGIDs.AntiCHadron
     _non_generator_specific = [id for id in PDGIDs if id not in _generator_specific]
     for id in _generator_specific:
         assert is_generator_specific(id) == True
@@ -303,7 +303,9 @@ def test_is_technicolor(PDGIDs):
 
 def test_is_composite_quark_or_lepton(PDGIDs):
     _composite_quark_or_lepton = (PDGIDs.UQuarkStar, PDGIDs.AntiElectronStar)
-    _non_composite_quark_or_lepton = [id for id in PDGIDs if id not in _composite_quark_or_lepton]
+    _non_composite_quark_or_lepton = [
+        id for id in PDGIDs if id not in _composite_quark_or_lepton
+    ]
     for id in _composite_quark_or_lepton:
         assert is_composite_quark_or_lepton(id) == True
     for id in _non_composite_quark_or_lepton:

--- a/tests/pdgid/test_functions.py
+++ b/tests/pdgid/test_functions.py
@@ -156,6 +156,7 @@ def test_is_meson(PDGIDs):
         PDGIDs.BPlus,
         PDGIDs.Bs,
         PDGIDs.BcPlus,
+        PDGIDs.Pi0TC,
         PDGIDs.PiMinusTC,
         PDGIDs.T0,
         PDGIDs.Reggeon,
@@ -458,6 +459,7 @@ def test_has_fundamental_anti(PDGIDs):
         PDGIDs.CTildeR,
         PDGIDs.DyonSameMagElecChargeSign,
         PDGIDs.DyonOppositeMagElecChargeSign,
+        PDGIDs.AntiCHadron,
     )
     _nope = [id for id in PDGIDs if id not in _yep]
     for id in _yep:

--- a/tests/pdgid/test_functions.py
+++ b/tests/pdgid/test_functions.py
@@ -117,6 +117,7 @@ def test_is_lepton(PDGIDs):
         PDGIDs.TauPrime,
         PDGIDs.Nu_e,
         PDGIDs.NuBar_tau,
+        PDGIDs.AntiElectronStar,
     )
     _non_leptons = [id for id in PDGIDs if id not in _leptons]
     for id in _leptons:
@@ -155,6 +156,7 @@ def test_is_meson(PDGIDs):
         PDGIDs.BPlus,
         PDGIDs.Bs,
         PDGIDs.BcPlus,
+        PDGIDs.PiMinusTC,
         PDGIDs.T0,
         PDGIDs.Reggeon,
         PDGIDs.Pomeron,
@@ -225,7 +227,7 @@ def test_is_sm_gauge_boson_or_higgs(PDGIDs):
 
 
 def test_is_generator_specific(PDGIDs):
-    _generator_specific = PDGIDs.AntiCHadron
+    _generator_specific = (PDGIDs.AntiCHadron,)
     _non_generator_specific = [id for id in PDGIDs if id not in _generator_specific]
     for id in _generator_specific:
         assert is_generator_specific(id) == True
@@ -298,7 +300,7 @@ def test_is_technicolor(PDGIDs):
     for id in _technicolor:
         assert is_technicolor(id) == True
     for id in _non_technicolor:
-        assert is_SUSY(id) == False
+        assert is_technicolor(id) == False
 
 
 def test_is_composite_quark_or_lepton(PDGIDs):
@@ -450,6 +452,8 @@ def test_has_fundamental_anti(PDGIDs):
         PDGIDs.TQuark,
         PDGIDs.BPrimeQuark,
         PDGIDs.TPrimeQuark,
+        PDGIDs.UQuarkStar,
+        PDGIDs.AntiElectronStar,
         PDGIDs.STildeL,
         PDGIDs.CTildeR,
         PDGIDs.DyonSameMagElecChargeSign,

--- a/tests/pdgid/test_functions.py
+++ b/tests/pdgid/test_functions.py
@@ -13,13 +13,17 @@ from particle.pdgid import is_lepton
 from particle.pdgid import is_hadron
 from particle.pdgid import is_meson
 from particle.pdgid import is_baryon
-from particle.pdgid import is_diquark
-from particle.pdgid import is_nucleus
 from particle.pdgid import is_pentaquark
+from particle.pdgid import is_sm_gauge_boson_or_higgs
+from particle.pdgid import is_generator_specific
+from particle.pdgid import is_nucleus
+from particle.pdgid import is_diquark
 from particle.pdgid import is_Rhadron
 from particle.pdgid import is_Qball
 from particle.pdgid import is_dyon
 from particle.pdgid import is_SUSY
+from particle.pdgid import is_technicolor
+from particle.pdgid import is_composite_quark_or_lepton
 from particle.pdgid import has_down
 from particle.pdgid import has_up
 from particle.pdgid import has_strange
@@ -196,15 +200,6 @@ def test_is_hadron(PDGIDs):
         assert is_hadron(id) == (is_meson(id) or is_baryon(id))
 
 
-def test_is_diquark(PDGIDs):
-    _diquarks = (PDGIDs.DD1, PDGIDs.SD0)
-    _non_diquarks = [id for id in PDGIDs if id not in _diquarks]
-    for id in _diquarks:
-        assert is_diquark(id) == True
-    for id in _non_diquarks:
-        assert is_diquark(id) == False
-
-
 def test_is_pentaquark(PDGIDs):
     _pentaquarks = (PDGIDs.UCbarCUDPentaquark, PDGIDs.AntiUCbarCUDPentaquark)
     _non_pentaquarks = [id for id in PDGIDs if id not in _pentaquarks]
@@ -212,6 +207,30 @@ def test_is_pentaquark(PDGIDs):
     assert is_pentaquark(PDGIDs.AntiUCbarCUDPentaquark) == True
     for id in _non_pentaquarks:
         assert is_pentaquark(id) == False
+
+
+def test_is_sm_gauge_boson_or_higgs(PDGIDs):
+    _sm_gb_and_higgs = (
+        PDGIDs.Gluon,
+        PDGIDs.Photon,
+        PDGIDs.Z0,
+        PDGIDs.WMinus,
+        PDGIDs.HiggsBoson
+    )
+    _non_sm_gb_and_higgs = [id for id in PDGIDs if id not in _sm_gb_and_higgs]
+    for id in _sm_gb_and_higgs:
+        assert is_sm_gauge_boson_or_higgs(id) == True
+    for id in _non_sm_gb_and_higgs:
+        assert is_sm_gauge_boson_or_higgs(id) == False
+
+
+def test_is_generator_specific(PDGIDs):
+    _generator_specific = (PDGIDs.AntiCHadron)
+    _non_generator_specific = [id for id in PDGIDs if id not in _generator_specific]
+    for id in _generator_specific:
+        assert is_generator_specific(id) == True
+    for id in _non_generator_specific:
+        assert is_generator_specific(id) == False
 
 
 def test_is_nucleus(PDGIDs):
@@ -226,6 +245,15 @@ def test_is_nucleus(PDGIDs):
         assert is_nucleus(id) == True
     for id in _non_nuclei:
         assert is_nucleus(id) == False
+
+
+def test_is_diquark(PDGIDs):
+    _diquarks = (PDGIDs.DD1, PDGIDs.SD0)
+    _non_diquarks = [id for id in PDGIDs if id not in _diquarks]
+    for id in _diquarks:
+        assert is_diquark(id) == True
+    for id in _non_diquarks:
+        assert is_diquark(id) == False
 
 
 def test_is_Rhadron(PDGIDs):
@@ -262,6 +290,24 @@ def test_is_SUSY(PDGIDs):
         assert is_SUSY(id) == True
     for id in _non_susy:
         assert is_SUSY(id) == False
+
+
+def test_is_technicolor(PDGIDs):
+    _technicolor = (PDGIDs.Pi0TC, PDGIDs.PiMinusTC)
+    _non_technicolor = [id for id in PDGIDs if id not in _technicolor]
+    for id in _technicolor:
+        assert is_technicolor(id) == True
+    for id in _non_technicolor:
+        assert is_SUSY(id) == False
+
+
+def test_is_composite_quark_or_lepton(PDGIDs):
+    _composite_quark_or_lepton = (PDGIDs.UQuarkStar, PDGIDs.AntiElectronStar)
+    _non_composite_quark_or_lepton = [id for id in PDGIDs if id not in _composite_quark_or_lepton]
+    for id in _composite_quark_or_lepton:
+        assert is_composite_quark_or_lepton(id) == True
+    for id in _non_composite_quark_or_lepton:
+        assert is_composite_quark_or_lepton(id) == False
 
 
 def test_has_down(PDGIDs):

--- a/tests/pdgid/test_pdgid.py
+++ b/tests/pdgid/test_pdgid.py
@@ -65,13 +65,17 @@ is_Qball       False
 is_Rhadron     False
 is_SUSY        False
 is_baryon      False
+is_composite_quark_or_lepton False
 is_diquark     False
 is_dyon        False
+is_generator_specific False
 is_hadron      False
 is_lepton      False
 is_meson       False
 is_nucleus     False
 is_pentaquark  False
+is_sm_gauge_boson_or_higgs True
+is_technicolor False
 is_valid       True
 j_spin         3
 l_spin         None


### PR DESCRIPTION
Indeed, as seen in the PDG  Monte Carlo Particle Numbering Scheme document https://pdg.lbl.gov/2020/reviews/rpp2020-rev-monte-carlo-numbering.pdf, the PDG ID encodes a series of (pseudo)particles or concepts that the code did not yet deal with - these were also not dealt with in the C++ HepPID package.