### PR TITLE
Remove misleading/awkward/unexpected Particle.__init__ method

### DIFF
--- a/notebooks/ParticleDemo.ipynb
+++ b/notebooks/ParticleDemo.ipynb
@@ -559,7 +559,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[int(p) for p in all_particles]"
+    "[int(p.pdgid) for p in all_particles]"
    ]
   },
   {

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -590,11 +590,11 @@ class Particle(object):
         # Sort by absolute particle numbers
         # The positive one should come first
         if type(self) == type(other):
-            return abs(int(self) - 0.25) < abs(int(other) - 0.25)
+            return abs(int(self.pdgid) - 0.25) < abs(int(other.pdgid) - 0.25)
 
         # Comparison with anything else should produce normal comparisons.
         else:
-            return int(self) < other
+            return int(self.pdgid) < other
 
     def __eq__(self, other):
         # type: (Any) -> bool
@@ -1038,9 +1038,9 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
             # particle=True is particle, False is antiparticle, and None is both
             if particle is not None:
-                if particle and int(item) < 0:
+                if particle and int(item.pdgid) < 0:
                     continue
-                elif (not particle) and int(item) > 0:
+                elif (not particle) and int(item.pdgid) > 0:
                     continue
 
             # If a filter function is passed, evaluate and skip if False

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -608,11 +608,6 @@ class Particle(object):
         # type: () -> int
         return hash(self.pdgid)
 
-    # Integer == PDGID
-    def __int__(self):
-        # type: () -> int
-        return int(self.pdgid)
-
     # Shared with PDGID
 
     @property

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -149,8 +149,8 @@ def test_pdg():
 def test_pdg_convert():
     p = Particle.from_pdgid(211)
     assert isinstance(p.pdgid, PDGID)
-    assert int(p) == 211
-    assert PDGID(p) == 211
+    assert p.pdgid == 211
+    assert int(p.pdgid) == 211
 
 
 def test_sorting():
@@ -576,7 +576,6 @@ ampgen_style_names = (
 def test_ampgen_style_names(name, pid):
     particle = Particle.from_string(name)
 
-    assert int(particle) == pid
     assert particle.pdgid == pid
     assert particle == pid
 


### PR DESCRIPTION
Addresses some bits of discussion in https://github.com/scikit-hep/particle/issues/263.