### PR TITLE
Enhance Particle.to_list and to_dict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         python-version:
         - 2.7
-        - 3.5
+        - 3.6
         - 3.8
         - 3.9
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - id: end-of-file-fixer
   - id: fix-encoding-pragma
 - repo: https://github.com/mgedmin/check-manifest
-  rev: "0.45"
+  rev: "0.44"
   hooks:
   - id: check-manifest
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - id: end-of-file-fixer
   - id: fix-encoding-pragma
 - repo: https://github.com/mgedmin/check-manifest
-  rev: "0.44"
+  rev: "0.45"
   hooks:
   - id: check-manifest
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ test =
 dev =
     pytest
     pandas; python_version>"3.4"
+    tabulate
     check-manifest>=0.42
     black==20.8b1
     mypy==0.790

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ where=src
 test =
     pytest
     pandas; python_version>"3.4"
+    tabulate
 dev =
     pytest
     pandas; python_version>"3.4"

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ dev =
 all =
     pytest
     pandas; python_version>"3.4"
+    tabulate
     check-manifest>=0.42
     black==20.8b1
     mypy==0.790

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -285,6 +285,8 @@ class Particle(object):
         exclude_fields=(),  # type: Iterable[str]
         n_rows=-1,  # type: int
         filter_fn=None,  # type: Optional[Callable[[Particle], bool]]
+        particle=None,  # type: Optional[bool]
+        **search_terms  # type: Any
     ):
         # type: (...) -> List[List[Any]]
         """
@@ -328,6 +330,11 @@ class Particle(object):
         filter_fn: function, optional, default is None
             Apply a filter to each particle.
             See `findall(...)`` for typical use cases.
+        particle: bool, optional, default is None
+            Pass particle=True/False to only return particles or antiparticles.
+            Option passed on internally to `findall(...)``.
+        search_terms: keyword arguments, optional
+            See `findall(...)`` for typical use cases.
 
         Returns
         -------
@@ -353,21 +360,24 @@ class Particle(object):
 
         Request the properties of a specific list of particles:
 
-        >>> query_as_list = Particle.to_list(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'])
+        >>> query_as_list = Particle.to_list(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'], particle=False)
 
         >>> print(tabulate(query_as_list, headers='firstrow', tablefmt="rst", floatfmt=".12g", numalign="decimal"))
         =======  ======  ===============  ========
           pdgid  name               mass    charge
         =======  ======  ===============  ========
-             11  e-         0.5109989461        -1
             -11  e+         0.5109989461         1
-             13  mu-      105.6583745           -1
             -13  mu+      105.6583745            1
-             15  tau-    1776.86                -1
             -15  tau+    1776.86                 1
-             17  tau'-                          -1
             -17  tau'+                           1
         =======  ======  ===============  ========
+
+        >>> query_as_list = Particle.to_list(filter_fn=lambda p: p.pdgid.is_lepton, pdg_name='tau', exclusive_fields=['pdgid', 'name', 'mass', 'charge'])
+        >>> print(tabulate(query_as_list, headers='firstrow'))
+          pdgid  name       mass    charge
+        -------  ------  -------  --------
+             15  tau-    1776.86        -1
+            -15  tau+    1776.86         1
 
         Save it to a file:
 
@@ -396,7 +406,7 @@ class Particle(object):
 
         # Apply a filter, if specified
         if filter_fn is not None:
-            tbl_all = cls.findall(filter_fn)
+            tbl_all = cls.findall(filter_fn, particle, **search_terms)
 
         # In any case, only keep a given number of rows?
         if n_rows >= 0:
@@ -416,6 +426,8 @@ class Particle(object):
         """
         Render a search (via `findall`) on the internal particle data CSV table
         as a `dict`, loading the table from the default location if no table has yet been loaded.
+
+        See `to_list` for details on the full function signature.
 
         The returned attributes are those of the class. By default all attributes
         are used as fields. Their complete list is:
@@ -454,6 +466,11 @@ class Particle(object):
         filter_fn: function, optional, default is None
             Apply a filter to each particle.
             See `findall(...)`` for typical use cases.
+        particle: bool, optional, default is None
+            Pass particle=True/False to only return particles or antiparticles.
+            Option passed on internally to `findall(...)``.
+        search_terms: keyword arguments, optional
+            See `findall(...)`` for typical use cases.
 
         Returns
         -------
@@ -479,21 +496,23 @@ class Particle(object):
 
         Request the properties of a specific list of particles:
 
-        >>> query_as_dict = Particle.to_dict(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'])
-
+        >>> query_as_dict = Particle.to_dict(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'], particle=True)
         >>> print(tabulate(query_as_dict, headers='keys', tablefmt="rst", floatfmt=".12g", numalign="decimal"))    # doctest: +SKIP
         =======  ======  ===============  ========
           pdgid  name               mass    charge
         =======  ======  ===============  ========
              11  e-         0.5109989461        -1
-            -11  e+         0.5109989461         1
              13  mu-      105.6583745           -1
-            -13  mu+      105.6583745            1
              15  tau-    1776.86                -1
-            -15  tau+    1776.86                 1
              17  tau'-                          -1
-            -17  tau'+                           1
         =======  ======  ===============  ========
+
+        >>> query_as_dict = Particle.to_dict(filter_fn=lambda p: p.pdgid.is_lepton, pdg_name='tau', exclusive_fields=['pdgid', 'name', 'mass', 'charge'])
+        >>> print(tabulate(query_as_dict, headers='keys'))
+          pdgid  name       mass    charge
+        -------  ------  -------  --------
+             15  tau-    1776.86        -1
+            -15  tau+    1776.86         1
 
         Save it to a file:
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -349,19 +349,25 @@ class Particle(object):
         --------
         Reproduce the whole particle table kept internally:
 
-        >>> Particle.to_list()    # doctest: +SKIP
+        >>> query_as_list = Particle.to_list()
 
         Reduce the information on the particle table to the only fields
         ['pdgid', 'pdg_name'] and render the first 5 particles:
 
         >>> query_as_list = Particle.to_list(exclusive_fields=['pdgid', 'pdg_name'], n_rows=5)
         >>> from tabulate import tabulate
-        >>> print(tabulate(query_as_list, headers='firstrow'))    # doctest: +SKIP
+        >>> print(tabulate(query_as_list, headers='firstrow'))
+          pdgid  pdg_name
+        -------  ----------
+              1  d
+             -1  d
+              2  u
+             -2  u
+              3  s
 
         Request the properties of a specific list of particles:
 
         >>> query_as_list = Particle.to_list(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'], particle=False)
-
         >>> print(tabulate(query_as_list, headers='firstrow', tablefmt="rst", floatfmt=".12g", numalign="decimal"))
         =======  ======  ===============  ========
           pdgid  name               mass    charge
@@ -485,19 +491,26 @@ class Particle(object):
         --------
         Reproduce the whole particle table kept internally:
 
-        >>> Particle.to_dict()    # doctest: +SKIP
+        >>> query_as_dict = Particle.to_dict()
 
         Reduce the information on the particle table to the only fields
         ['pdgid', 'pdg_name'] and render the first 5 particles:
 
         >>> query_as_dict = Particle.to_dict(exclusive_fields=['pdgid', 'pdg_name'], n_rows=5)
-        >>> from tabulate import tabulate    # doctest: +SKIP
-        >>> print(tabulate(query_as_dict, headers='keys'))    # doctest: +SKIP
+        >>> from tabulate import tabulate
+        >>> print(tabulate(query_as_dict, headers='keys'))
+          pdgid  pdg_name
+        -------  ----------
+              1  d
+             -1  d
+              2  u
+             -2  u
+              3  s
 
         Request the properties of a specific list of particles:
 
         >>> query_as_dict = Particle.to_dict(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'], particle=True)
-        >>> print(tabulate(query_as_dict, headers='keys', tablefmt="rst", floatfmt=".12g", numalign="decimal"))    # doctest: +SKIP
+        >>> print(tabulate(query_as_dict, headers='keys', tablefmt="rst", floatfmt=".12g", numalign="decimal"))
         =======  ======  ===============  ========
           pdgid  name               mass    charge
         =======  ======  ===============  ========

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -497,8 +497,8 @@ class Particle(object):
         ['pdgid', 'pdg_name'] and render the first 5 particles:
 
         >>> query_as_dict = Particle.to_dict(exclusive_fields=['pdgid', 'pdg_name'], n_rows=5)
-        >>> from tabulate import tabulate
-        >>> print(tabulate(query_as_dict, headers='keys'))
+        >>> from tabulate import tabulate    # doctest: +SKIP
+        >>> print(tabulate(query_as_dict, headers='keys'))    # doctest: +SKIP
           pdgid  pdg_name
         -------  ----------
               1  d

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -288,7 +288,7 @@ class Particle(object):
         particle=None,  # type: Optional[bool]
         **search_terms  # type: Any
     ):
-        # type: (...) -> List[List[Union[bool, int, str, float]]]
+        # type: (...) -> List[List[Any]]
         """
         Render a search (via `findall`) on the internal particle data CSV table
         as a `list`, loading the table from the default location if no table has yet been loaded.

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -510,7 +510,7 @@ class Particle(object):
         Request the properties of a specific list of particles:
 
         >>> query_as_dict = Particle.to_dict(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'], particle=True)
-        >>> print(tabulate(query_as_dict, headers='keys', tablefmt="rst", floatfmt=".12g", numalign="decimal"))
+        >>> print(tabulate(query_as_dict, headers='keys', tablefmt="rst", floatfmt=".12g", numalign="decimal"))    # doctest: +SKIP
         =======  ======  ===============  ========
           pdgid  name               mass    charge
         =======  ======  ===============  ========
@@ -521,7 +521,7 @@ class Particle(object):
         =======  ======  ===============  ========
 
         >>> query_as_dict = Particle.to_dict(filter_fn=lambda p: p.pdgid.is_lepton, pdg_name='tau', exclusive_fields=['pdgid', 'name', 'mass', 'charge'])
-        >>> print(tabulate(query_as_dict, headers='keys'))
+        >>> print(tabulate(query_as_dict, headers='keys'))    # doctest: +SKIP
           pdgid  name       mass    charge
         -------  ------  -------  --------
              15  tau-    1776.86        -1


### PR DESCRIPTION
Add more filter functionality to `Particle.to_list` and `Particle.to_dict` since these 2 methods rely internally on `Particle.findall`, and the latter allows for more arguments than the former methods presently accepted. This PR makes the signatures of these methods match.