### PR TITLE
Add tests to check if every particle is parsed and added correctly

### DIFF
--- a/src/particle/particle/enums.py
+++ b/src/particle/particle/enums.py
@@ -37,7 +37,6 @@ class Parity(IntEnum):
     p = 1
     m = -1
     u = 5
-    x = -5
 
 
 class Charge(IntEnum):

--- a/src/particle/particle/enums.py
+++ b/src/particle/particle/enums.py
@@ -37,6 +37,7 @@ class Parity(IntEnum):
     p = 1
     m = -1
     u = 5
+    x = -5
 
 
 class Charge(IntEnum):

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -348,6 +348,21 @@ def test_explicit_table_loading():
     assert Particle.all() is not None
 
 
+def test_all_particles_are_loaded():
+    Particle.load_table(data.open_text(data, "particle2018.csv"))
+    assert len(Particle.all()) == 605
+    Particle.load_table(data.open_text(data, "particle2019.csv"))
+    assert len(Particle.all()) == 610
+    Particle.load_table(data.open_text(data, "particle2020.csv"))
+    assert len(Particle.all()) == 610
+
+    Particle.load_table(data.open_text(data, "nuclei2020.csv"))
+    assert len(Particle.all()) == 5880
+
+    # Load default table to restore global state
+    Particle.load_table()
+
+
 checklist_html_name = (
     (22, "&gamma;"),  # photon
     (1, "d"),  # d quark


### PR DESCRIPTION
I wanted to some cross-checks with the Julia package [Corpuscles.jl](https://github.com/JuliaPhysics/Corpuscles.jl) and noticed that some particles are not missing in all `particle*.csv` datasets after loading them. E.g. the currently default `particle2020.csv` contains a total of 610 particles, but only 603 are loaded:

```python
>>> from particle import Particle, data

>>> Particle.load_table(data.open_text(data, 'particle2020.csv'))

>>> len(Particle.findall())
603
```

I quickly created a diff to check which particles are missing compared to `Corpuscles.jl` and got:

```julia
julia> [Particle(p) for p in setdiff(Set(corpuscles_ids), Set(particle_ids))]
7-element Array{Particle,1}:
 Particle(-203338) Omega(2250)
 Particle(-103326) Xi(1950)
 Particle(-203316) Xi(2030)
 Particle(-103316) Xi(1950)
 Particle(-203326) Xi(2030)
 Particle(-203312) Xi(1690)
 Particle(-203322) Xi(1690)
```

A quick debug session in `particle` revealed that the problem is `Error: -5 is not a valid Parity` which is suppressed here: https://github.com/scikit-hep/particle/blob/4d58415cc3583192cf2e8df2a3881259fcbd806d/src/particle/particle/particle.py#L616 and originates from the enum `Parity`: https://github.com/scikit-hep/particle/blob/4d58415cc3583192cf2e8df2a3881259fcbd806d/src/particle/particle/enums.py#L34

There is already an enum entry for `Parity=5`, so this PR adds `-5`, named `x`.
