### PR TITLE
Add a .zenodo.json file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,24 @@
+{
+    "description": "PDG particle data and identification codes",
+    "license": "other-open",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "University of Liverpool",
+            "name": "Eduardo Rodrigues",
+            "orcid": "0000-0003-2846-7625"
+        },
+        {
+            "affiliation": "Princeton University",
+            "name": "Henry Schreiner",
+            "orcid": "0000-0002-7833-783X"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+        "High Energy Physics",
+        "PDG",
+        "particle data",
+        "MC identification codes"
+      ]
+}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,6 @@ prune .github
 exclude .coveragerc .pre-commit-config.yaml azure-pipelines.yml environment.yml
 
 include src/particle/version.py
-include LICENSE README.rst CONTRIBUTING.md pyproject.toml setup.py setup.cfg
+include LICENSE README.rst CONTRIBUTING.md pyproject.toml setup.py setup.cfg .zenodo.json
 
 recursive-include src py.typed


### PR DESCRIPTION
As per out chat, @matthewfeickert.

As you can see I'm not filling in all possible fields, e.g. the ones on versioning. I would say we go ahead assuming Zenodo will add the missing fields since anyway it *is* creating at present such a file, on the fly, from best-guesses, as it says on their site.

Let me know if you seen anything obvious missing. Otherwise approve :-). Advance thanks.