### PR TITLE
Programmatic name for diquarks and SUSY particles

### DIFF
--- a/src/particle/particle/literals.py
+++ b/src/particle/particle/literals.py
@@ -43,4 +43,4 @@ for k, v in common_particles.items():
 __doc__ = __doc__.format(__doc)
 
 
-del Particle, ParticleNotFound, common_particles
+del Particle, ParticleNotFound, common_particles, k, v

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -33,7 +33,7 @@ def programmatic_name(name):
         .replace("+", "_plus")
     )
     # Strip off the ugly "_" at beginning of a name, such as when dealing with name="(bs)(0)""
-    return re.sub("^_", "", name)
+    return name.lstrip("_")
 
 
 def str_with_unc(value, upper, lower=None):

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -19,7 +19,19 @@ def programmatic_name(name):
     name = re.sub("^~", "tilde_", name)
     # The remaining "~" now always means it's an antiparticle
     name = name if "~" not in name else "".join(name.split("~")) + "_bar"
-    name = name.replace(")(", "_").replace("(", "_").replace(")", "").replace("*", "st").replace("'", "p").replace("::", "_").replace("/", "").replace("--", "_mm").replace("++", "_pp").replace("-", "_minus").replace("+", "_plus")
+    name = (
+        name.replace(")(", "_")
+        .replace("(", "_")
+        .replace(")", "")
+        .replace("*", "st")
+        .replace("'", "p")
+        .replace("::", "_")
+        .replace("/", "")
+        .replace("--", "_mm")
+        .replace("++", "_pp")
+        .replace("-", "_minus")
+        .replace("+", "_plus")
+    )
     # Strip off the ugly "_" at beginning of a name, such as when dealing with name="(bs)(0)""
     return re.sub("^_", "", name)
 

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -19,17 +19,7 @@ def programmatic_name(name):
     name = re.sub("^~", "tilde_", name)
     # The remaining "~" now always means it's an antiparticle
     name = name if "~" not in name else "".join(name.split("~")) + "_bar"
-    name = name.replace(")(", "_")
-        .replace("(", "_")
-        .replace(")", "")
-        .replace("*", "st")
-        .replace("'", "p")
-        .replace("::", "_")
-        .replace("/", "")
-        .replace("--", "_mm")
-        .replace("++", "_pp")
-        .replace("-", "_minus")
-        .replace("+", "_plus")
+    name = name.replace(")(", "_").replace("(", "_").replace(")", "").replace("*", "st").replace("'", "p").replace("::", "_").replace("/", "").replace("--", "_mm").replace("++", "_pp").replace("-", "_minus").replace("+", "_plus")
     # Strip off the ugly "_" at beginning of a name, such as when dealing with name="(bs)(0)""
     return re.sub("^_", "", name)
 

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -19,8 +19,7 @@ def programmatic_name(name):
     name = re.sub("^~", "tilde_", name)
     # The remaining "~" now always means it's an antiparticle
     name = name if "~" not in name else "".join(name.split("~")) + "_bar"
-    name =
-        name.replace(")(", "_")
+    name = name.replace(")(", "_")
         .replace("(", "_")
         .replace(")", "")
         .replace("*", "st")

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -16,7 +16,7 @@ def programmatic_name(name):
     "Return a name safe to use as a variable name."
     name = re.sub("0$", "_0", name)
     # Deal first with antiparticles of sparticles, e.g. "~d(R)~" antiparticle of "~d(R)"
-    name = re.sub("^~", "tilde-", name)
+    name = re.sub("^~", "tilde_", name)
     # The remaining "~" now always means it's an antiparticle
     name = name if "~" not in name else "".join(name.split("~")) + "_bar"
     name =

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -15,8 +15,11 @@ def programmatic_name(name):
     # type: (str) -> str
     "Return a name safe to use as a variable name."
     name = re.sub("0$", "_0", name)
+    # Deal first with antiparticles of sparticles, e.g. "~d(R)~" antiparticle of "~d(R)"
+    name = re.sub("^~", "tilde-", name)
+    # The remaining "~" now always means it's an antiparticle
     name = name if "~" not in name else "".join(name.split("~")) + "_bar"
-    return (
+    name =
         name.replace(")(", "_")
         .replace("(", "_")
         .replace(")", "")
@@ -28,7 +31,8 @@ def programmatic_name(name):
         .replace("++", "_pp")
         .replace("-", "_minus")
         .replace("+", "_plus")
-    )
+    # Strip off the ugly "_" at beginning of a name, such as when dealing with name="(bs)(0)""
+    return re.sub("^_", "", name)
 
 
 def str_with_unc(value, upper, lower=None):

--- a/src/particle/pdgid/literals.py
+++ b/src/particle/pdgid/literals.py
@@ -44,4 +44,4 @@ __doc = "".join(
 )
 __doc__ = __doc__.format(__doc)
 
-del PDGID, common_particles
+del PDGID, common_particles, item


### PR DESCRIPTION
The programmatic names of diquarks such as `(bs)(0)` where returned as `_bs_0`, where the prefix `_` is not so pretty. This PR introduces a trivial adaptation to rather return  `bs_0` and similarly for the other diquarks.

(OK, diquarks are not observed particles so this is largely academic/aesthetics.)

Some temporary variables were also exposed. Now that are removed, the right thing to do.