### PR TITLE
Fix unreasonably slow import time

### DIFF
--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -585,37 +585,40 @@ class Particle(object):
         with open_file as f:
             r = csv.DictReader(line for line in f if not line.startswith("#"))
 
+            # Use a set to avoid making this O(n^2)
+            known_particles = set(cls._table)
             for v in r:
                 try:
                     value = int(v["ID"])
 
                     # Replace the previous value if it exists
                     # We can remove an int; ignore typing thinking we need a particle
-                    if value in cls._table:
+                    if value in known_particles:
                         cls._table.remove(value)  # type: ignore
+                        known_particles.remove(value)  # type: ignore
 
-                    cls._table.append(
-                        cls(
-                            pdgid=value,
-                            mass=float(v["Mass"]),
-                            mass_upper=float(v["MassUpper"]),
-                            mass_lower=float(v["MassLower"]),
-                            width=float(v["Width"]),
-                            width_upper=float(v["WidthUpper"]),
-                            width_lower=float(v["WidthLower"]),
-                            I=v["I"],
-                            G=int(v["G"]),
-                            P=int(v["P"]),
-                            C=int(v["C"]),
-                            anti_flag=int(v["Anti"]),
-                            three_charge=int(v["Charge"]),
-                            rank=int(v["Rank"]),
-                            status=int(v["Status"]),
-                            pdg_name=v["Name"],
-                            quarks=v["Quarks"],
-                            latex_name=v["Latex"],
-                        )
+                    p = cls(
+                        pdgid=value,
+                        mass=float(v["Mass"]),
+                        mass_upper=float(v["MassUpper"]),
+                        mass_lower=float(v["MassLower"]),
+                        width=float(v["Width"]),
+                        width_upper=float(v["WidthUpper"]),
+                        width_lower=float(v["WidthLower"]),
+                        I=v["I"],
+                        G=int(v["G"]),
+                        P=int(v["P"]),
+                        C=int(v["C"]),
+                        anti_flag=int(v["Anti"]),
+                        three_charge=int(v["Charge"]),
+                        rank=int(v["Rank"]),
+                        status=int(v["Status"]),
+                        pdg_name=v["Name"],
+                        quarks=v["Quarks"],
+                        latex_name=v["Latex"],
                     )
+                    cls._table.append(p)
+                    known_particles.add(p)
                 except ValueError:
                     pass
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -587,7 +587,7 @@ class Particle(object):
 
             # Use a set to avoid making this O(n^2)
             known_particles = set(cls._table)
-            
+
             for v in r:
                 try:
                     value = int(v["ID"])

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -587,6 +587,7 @@ class Particle(object):
 
             # Use a set to avoid making this O(n^2)
             known_particles = set(cls._table)
+            
             for v in r:
                 try:
                     value = int(v["ID"])
@@ -594,7 +595,6 @@ class Particle(object):
                     # Replace the previous value if it exists
                     # We can remove an int; ignore typing thinking we need a particle
                     if value in known_particles:
-                        cls._table.remove(value)  # type: ignore
                         known_particles.remove(value)  # type: ignore
 
                     p = cls(
@@ -617,12 +617,11 @@ class Particle(object):
                         quarks=v["Quarks"],
                         latex_name=v["Latex"],
                     )
-                    cls._table.append(p)
                     known_particles.add(p)
                 except ValueError:
                     pass
 
-        cls._table = sorted(cls._table)
+        cls._table = sorted(known_particles)
 
     # The following __le__ and __eq__ needed for total ordering (sort, etc)
 


### PR DESCRIPTION
Importing particle 0.16.0 takes an unreasonably long time:

```python
In [1]: %time import particle
CPU times: user 12.2 s, sys: 85.2 ms, total: 12.3 s
Wall time: 12.5 s
```

This is due to the use of `if value in cls._table:` inside the `Particle.load_table` which causes it be O(n²) with `Particle.__eq__` currently being called 21,095,760 million times.

This PR does the most backwards compatible fix possible by using a `set` to reduce this down to O(n):

```python
In [1]: %time import particle
CPU times: user 189 ms, sys: 13.7 ms, total: 202 ms
Wall time: 212 ms
```

IMHO a better solution might be to change `Particle._table` to be a `set` but this would change the public API and result in the ordering being lost.