### PR TITLE
chore: renable missing Python 3.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.8", "3.9", "3.10-dev"]
+        python-version: ["2.7", "3.5", "3.6", "3.8", "3.9", "3.10-dev"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   rev: v1.17.0
   hooks:
   - id: setup-cfg-fmt
-    args: [--max-py-version=3.10]
+    args: [--max-py-version=3.10, --min-py3-version=3.5]
 
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.25.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -45,7 +46,7 @@ install_requires =
     importlib_resources>=2.0;python_version<"3.9"
     typing>=3.7;python_version<"3.5"
     typing_extensions;python_version<"3.8"
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 include_package_data = True
 package_dir =
     =src


### PR DESCRIPTION
This was only missing due to setup-cfg-fmt's default 3.6+, I believe.