### PR TITLE
style: ignore a Python 3 only style check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,5 +85,5 @@ addopts = '-Wd'
 
 [flake8]
 max-complexity = 24
-ignore = E203, E231, E501, E722, W503, B950, E402
+ignore = E203, E231, E501, E722, W503, B950, E402, B904
 select = C,E,F,W,B,B9


### PR DESCRIPTION
We don't pin flake8-bugbear, and it seems to have a default Python 3 only check. Pretty reasonable now, but we still sadly support Python 2. I'd love to drop all Python 2 support across Scikit-HEP Jan 1, 2022!