### PR TITLE
Add new class method Particle.from_name

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 0.16.3 (WIP)
+--------------
+
+- `Particle` class:
+  - New class method `Particle.from_name`.
+
 
 Version 0.16.2
 --------------

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -1054,11 +1054,13 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             If no particle matches the input name.
         """
         try:
-            (particle,) = Particle.finditer(name=name)  # throws an error if < 1 or > 1 particle is found
+            (particle,) = Particle.finditer(
+                name=name
+            )  # throws an error if < 1 or > 1 particle is found
             return particle
         except ValueError:
             raise ParticleNotFound(  # noqa: B904  <- use from None when Python 2 is dropped
-                "Could not find name \"{}\"".format(name)
+                'Could not find name "{}"'.format(name)
             )
 
     @classmethod

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -1043,6 +1043,40 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             )
 
     @classmethod
+    def from_name(cls, name):
+        # type: (str) -> Particle
+        """
+        Get a particle from its name.
+
+        Raises
+        ------
+        ParticleNotFound
+            If no particle matches the input name.
+        """
+        try:
+            (particle,) = Particle.finditer(name=name)  # throws an error if < 1 or > 1 particle is found
+            return particle
+        except ValueError:
+            raise ParticleNotFound(  # noqa: B904  <- use from None when Python 2 is dropped
+                "Could not find name \"{}\"".format(name)
+            )
+
+    @classmethod
+    def from_evtgen_name(cls, name):
+        # type: (str) -> Particle
+        """
+        Get a particle from an EvtGen particle name, as in .dec decay files.
+
+        Raises
+        ------
+        ParticleNotFound
+            If `from_pdgid`, internally called, returns no match.
+        MatchingIDNotFound
+            If the matching EvtGen name - PDG ID done internally is unsuccessful.
+        """
+        return cls.from_pdgid(EvtGenName2PDGIDBiMap[name])
+
+    @classmethod
     def finditer(
         cls,
         filter_fn=None,  # type: Optional[Callable[[Particle], bool]]
@@ -1226,21 +1260,6 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             )
         else:
             raise RuntimeError("Found too many particles")
-
-    @classmethod
-    def from_evtgen_name(cls, name):
-        # type: (str) -> Particle
-        """
-        Get a particle from an EvtGen particle name, as in .dec decay files.
-
-        Raises
-        ------
-        ParticleNotFound
-            If `from_pdgid` returns no match.
-        MatchingIDNotFound
-            If the matching EvtGen name - PDG ID done internally is unsuccessful.
-        """
-        return cls.from_pdgid(EvtGenName2PDGIDBiMap[name])
 
     @classmethod
     def from_string(cls, name):


### PR DESCRIPTION
Following the discussion at https://github.com/scikit-hep/particle/pull/354 and my suggestion, @henryiii and @jonas-eschle. Main reason is that we have `from_pdgid` and `from_evtgen_name` and it seemed awkward not to have `from_name`, the particle name itself.