### PR TITLE
fix: full static typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
   hooks:
   - id: mypy
     files: src
-    additional_dependencies: [attrs==21.3.0, types-deprecated, hepunits, importlib_resources]
+    additional_dependencies: [attrs==21.3.0, types-deprecated, hepunits>=2.2.0, importlib_resources]
     args: [--show-error-codes]
 
 - repo: https://github.com/codespell-project/codespell

--- a/notebooks/ParticleDemo.ipynb
+++ b/notebooks/ParticleDemo.ipynb
@@ -544,7 +544,7 @@
    "outputs": [],
    "source": [
     "all_particles = Particle.all()\n",
-    "print('The package \"DB\" contains {} particles:'.format(len(all_particles)))\n",
+    "print(f'The package \"DB\" contains {len(all_particles)} particles:')\n",
     "all_particles"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,9 @@ profile = "black"
 [tool.mypy]
 warn_unused_configs = true
 warn_unused_ignores = true
-python_version = "3.6"
+python_version = "3.9"
 files = "src"
-check_untyped_defs = true
-disallow_untyped_defs = true
+strict = true
 
 # NumPy is used lightly, so ignored here for now
 [[tool.mypy.overrides]]

--- a/src/particle/converters/bimap.py
+++ b/src/particle/converters/bimap.py
@@ -5,6 +5,7 @@
 
 
 import csv
+import sys
 from collections.abc import Mapping
 from typing import (
     Any,
@@ -217,7 +218,13 @@ def DirectionalMaps(
     )
 
 
-class DirectionalMap(Mapping[str, str]):
+if sys.version_info < (3, 9):
+    StrStrMapping = Mapping
+else:
+    StrStrMapping = Mapping[str, str]
+
+
+class DirectionalMap(StrStrMapping):
     def __init__(self, name_A: str, name_B: str, map: Dict[str, str]) -> None:
         """
         Directional map class providing a A -> B mapping.

--- a/src/particle/converters/bimap.py
+++ b/src/particle/converters/bimap.py
@@ -127,18 +127,16 @@ class BiMap(Generic[A, B]):
             except KeyError:
                 pass
 
-        msg = "Matching {a}-{b} for input {v} not found !".format(
-            a=self.class_A.__name__, b=self.class_B.__name__, v=value
-        )
+        name_A = self.class_A.__name__
+        name_B = self.class_B.__name__
+        msg = f"Matching {name_A}-{name_B} for input {value} not found !"
         raise MatchingIDNotFound(msg)
 
     def __repr__(self) -> str:
-        return "<{self.__class__.__name__}({a}-{b}): {n} matches>".format(
-            self=self,
-            a=self.class_A.__name__,
-            b=self.class_B.__name__,
-            n=self.__len__(),
-        )
+        name_A = self.class_A.__name__
+        name_B = self.class_B.__name__
+
+        return f"<{self.__class__.__name__}({name_A}-{name_B}): {len(self)} matches>"
 
     def __len__(self) -> int:
         """Returns the number of matches."""
@@ -241,18 +239,14 @@ class DirectionalMap(Mapping[str, str]):
         try:
             return self._map[value]
         except KeyError:
-            msg = "Matching {a}->{b} for input {v} not found !".format(
-                a=self.name_A, b=self.name_B, v=value
-            )
-            raise MatchingIDNotFound(msg)  # noqa: B904 Remove when dropping Python 2
+            msg = f"Matching {self.name_A}->{self.name_B} for input {value} not found !"
+            raise MatchingIDNotFound(msg) from None
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._map)
 
     def __repr__(self) -> str:
-        return "<{self.__class__.__name__}({a}->{b}): {n} matches>".format(
-            self=self, a=self.name_A, b=self.name_B, n=self.__len__()
-        )
+        return f"<{self.__class__.__name__}({self.name_A}->{self.name_B}): {len(self)} matches>"
 
     def __len__(self) -> int:
         """Returns the number of matches."""

--- a/src/particle/converters/bimap.py
+++ b/src/particle/converters/bimap.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     Generic,
     Iterator,
+    Optional,
     TextIO,
     Tuple,
     Type,
@@ -22,7 +23,7 @@ from typing import (
 
 from .. import data
 from ..exceptions import MatchingIDNotFound
-from ..typing import HasOpen, HasRead
+from ..typing import HasOpen, HasRead, StringOrIO
 
 A = TypeVar("A")
 B = TypeVar("B")
@@ -35,8 +36,8 @@ class BiMap(Generic[A, B]):
         self,
         class_A: Type[A],
         class_B: Type[B],
-        converters: Tuple[A_conv, B_conv] = (int, int),
-        filename: Union[str, TextIO, None] = None,
+        converters: Tuple[A_conv, B_conv] = (int, int),  # type: ignore[type-arg]
+        filename: Optional[StringOrIO] = None,
     ) -> None:
         """
         Bi-bidirectional map class.
@@ -84,6 +85,7 @@ class BiMap(Generic[A, B]):
         name_A = self.class_A.__name__.upper()
         name_B = self.class_B.__name__.upper()
 
+        file_object: TextIO
         if filename is None:
             filename = f"{name_A.lower()}_to_{name_B.lower()}.csv"
             file_object = data.basepath.joinpath(filename).open()
@@ -92,7 +94,7 @@ class BiMap(Generic[A, B]):
         elif isinstance(filename, HasOpen):
             file_object = filename.open()
         else:
-            file_object = open(filename)
+            file_object = open(filename)  # type: ignore[arg-type]
 
         with file_object as _f:
             self._to_map = {
@@ -147,7 +149,7 @@ def DirectionalMaps(
     name_A: str,
     name_B: str,
     converters: Tuple[Callable[[str], str], Callable[[str], str]] = (str, str),
-    filename: Union[None, str, TextIO] = None,
+    filename: Optional[StringOrIO] = None,
 ) -> Tuple["DirectionalMap", "DirectionalMap"]:
     """
     Directional map class providing a to and from mapping.
@@ -180,6 +182,7 @@ def DirectionalMaps(
     name_B = name_B.upper()
 
     fieldnames = None
+    file_object: TextIO
     if filename is None:
         file_object = data.basepath.joinpath("conversions.csv").open()
     elif isinstance(filename, HasOpen):
@@ -187,7 +190,7 @@ def DirectionalMaps(
     elif isinstance(filename, HasRead):
         file_object = filename
     else:
-        file_object = open(filename)
+        file_object = open(filename)  # type: ignore[arg-type]
 
     with file_object as _f:
         skipinitialspace = True
@@ -216,7 +219,7 @@ def DirectionalMaps(
     )
 
 
-class DirectionalMap(Mapping):
+class DirectionalMap(Mapping[str, str]):
     def __init__(self, name_A: str, name_B: str, map: Dict[str, str]) -> None:
         """
         Directional map class providing a A -> B mapping.

--- a/src/particle/particle/convert.py
+++ b/src/particle/particle/convert.py
@@ -52,7 +52,6 @@ When you are done, you can save one or more of the tables:
 
 import os
 from datetime import date
-from importlib.abc import Traversable
 from io import StringIO
 from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Tuple, TypeVar
 
@@ -61,7 +60,7 @@ import pandas as pd
 
 from .. import data
 from ..pdgid import PDGID, is_baryon
-from ..typing import StringOrIO
+from ..typing import StringOrIO, Traversable
 from .enums import (
     Charge,
     Charge_mapping,

--- a/src/particle/particle/convert.py
+++ b/src/particle/particle/convert.py
@@ -52,24 +52,16 @@ When you are done, you can save one or more of the tables:
 
 import os
 from datetime import date
+from importlib.abc import Traversable
 from io import StringIO
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Optional,
-    TextIO,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Tuple, TypeVar
 
 import numpy as np
 import pandas as pd
 
 from .. import data
 from ..pdgid import PDGID, is_baryon
+from ..typing import StringOrIO
 from .enums import (
     Charge,
     Charge_mapping,
@@ -95,7 +87,7 @@ def __dir__() -> Tuple[str, ...]:
     return __all__
 
 
-def get_from_latex(filename: str) -> pd.Series:
+def get_from_latex(filename: StringOrIO) -> pd.Series:
     """
     Produce a pandas series from a file with LaTeX mappings in itself.
     The CVS file format is the following: PDGID, ParticleLatexName.
@@ -104,7 +96,7 @@ def get_from_latex(filename: str) -> pd.Series:
     return latex_table.LATEXNAME
 
 
-def filter_file(fileobject: Union[str, TextIO]) -> TextIO:
+def filter_file(fileobject: StringOrIO) -> TextIO:
     """
     Open a file if not already a file-like object, and strip lines that start with *.
     Returns a new file-like object (StringIO instance).
@@ -114,7 +106,7 @@ def filter_file(fileobject: Union[str, TextIO]) -> TextIO:
         assert isinstance(fileobject, str)
         fileobject = open(fileobject, encoding="utf-8")
 
-    assert not isinstance(fileobject, str)
+    assert not isinstance(fileobject, (str, Traversable))
 
     stream = StringIO()
     for line in fileobject:
@@ -132,7 +124,9 @@ def filter_file(fileobject: Union[str, TextIO]) -> TextIO:
 T = TypeVar("T")
 
 
-def get_from_pdg_extended(filename: str, latexes: Iterable[str] = ()) -> pd.DataFrame:
+def get_from_pdg_extended(
+    filename: StringOrIO, latexes: Iterable[StringOrIO] = ()
+) -> pd.DataFrame:
     """
     Read an "extended style" PDG data file (only produced in 2008), plus a list of LaTeX files,
     to produce a pandas DataFrame with particle information.
@@ -271,7 +265,7 @@ def sort_particles(table: pd.DataFrame) -> None:
     del table["TmpVals"]
 
 
-def get_from_pdg_mcd(filename: str) -> pd.DataFrame:
+def get_from_pdg_mcd(filename: StringOrIO) -> pd.DataFrame:
     """
     Reads in a current-style PDG .mcd file (mass_width_2021.mcd file tested).
 
@@ -445,7 +439,7 @@ def main(version: str, year: str) -> None:
 
 
 def convert(version: str, output: str, fwf: str, latex: Optional[str] = None) -> None:
-    latexes = [data.basepath / "pdgid_to_latexname.csv"]
+    latexes: List[StringOrIO] = [data.basepath / "pdgid_to_latexname.csv"]
     if latex:
         latexes.append(latex)
     table = get_from_pdg_extended(fwf, latexes)

--- a/src/particle/particle/convert.py
+++ b/src/particle/particle/convert.py
@@ -387,7 +387,7 @@ def produce_files(
     full_table.drop([30221, 100223, 5132, 5232], axis=0, inplace=True)
 
     # No longer write out the particle2008.csv file, which nobody should use
-    # particle2008 = str(particle2008)  # Conversion to handle pathlib on Python < 3.6
+    # particle2008 = str(particle2008)  # Conversion to handle pathlib on Python < 3.6.1
     # with open(particle2008, "w", newline="\n", encoding="utf-8") as f:
     # f.write(version_header(particle2008, version))
     # full_table.to_csv(f, float_format="%.12g")
@@ -413,7 +413,7 @@ def produce_files(
 
     new_table = update_from_mcd(full_table, ext_table)
 
-    particle2021 = str(particle2021)  # Conversion to handle pathlib on Python < 3.6
+    particle2021 = str(particle2021)  # Conversion to handle pathlib on Python < 3.6.1
     with open(particle2021, "w", newline="\n", encoding="utf-8") as f:
         f.write(version_header(particle2021, version))
         new_table.to_csv(f, float_format="%.12g")
@@ -421,11 +421,9 @@ def produce_files(
 
 def version_header(filename: str, version_number: str) -> str:
     filename = os.path.basename(filename)
-    VERSION = version_number  # version of CSV files
-    DATE = date.isoformat(date.today())
-    return "# (c) Scikit-HEP project - Particle package data file - {fname} - version {version} - {date}\n".format(
-        fname=filename, version=VERSION, date=DATE
-    )
+    version = version_number  # version of CSV files
+    today_date = date.isoformat(date.today())
+    return f"# (c) Scikit-HEP project - Particle package data file - {filename} - version {version} - {today_date}\n"
 
 
 def main(version: str, year: str) -> None:

--- a/src/particle/particle/kinematics.py
+++ b/src/particle/particle/kinematics.py
@@ -8,9 +8,8 @@ Functions relevant to particle kinematics.
 """
 
 
-# Bug in HEPUnits exporting
-from hepunits.constants import hbar  # type: ignore[attr-defined]
-from hepunits.units import MeV, ns  # type: ignore[attr-defined]
+from hepunits.constants import hbar
+from hepunits.units import MeV, ns
 
 
 def width_to_lifetime(Gamma: float) -> float:
@@ -55,7 +54,7 @@ def width_to_lifetime(Gamma: float) -> float:
         return float("inf")
 
     # Just need to first make sure that the width is in the standard unit MeV
-    return hbar / float(Gamma / MeV)  # type: ignore[no-any-return]
+    return hbar / float(Gamma / MeV)
 
 
 def lifetime_to_width(tau: float) -> float:
@@ -101,4 +100,4 @@ def lifetime_to_width(tau: float) -> float:
         return float("inf")
 
     # Just need to first make sure that the lifetime is in the standard unit ns
-    return hbar / float(tau / ns)  # type: ignore[no-any-return]
+    return hbar / float(tau / ns)

--- a/src/particle/particle/kinematics.py
+++ b/src/particle/particle/kinematics.py
@@ -8,8 +8,9 @@ Functions relevant to particle kinematics.
 """
 
 
-from hepunits.constants import hbar
-from hepunits.units import MeV, ns
+# Bug in HEPUnits exporting
+from hepunits.constants import hbar  # type: ignore[attr-defined]
+from hepunits.units import MeV, ns  # type: ignore[attr-defined]
 
 
 def width_to_lifetime(Gamma: float) -> float:
@@ -54,7 +55,7 @@ def width_to_lifetime(Gamma: float) -> float:
         return float("inf")
 
     # Just need to first make sure that the width is in the standard unit MeV
-    return hbar / float(Gamma / MeV)
+    return hbar / float(Gamma / MeV)  # type: ignore[no-any-return]
 
 
 def lifetime_to_width(tau: float) -> float:
@@ -100,4 +101,4 @@ def lifetime_to_width(tau: float) -> float:
         return float("inf")
 
     # Just need to first make sure that the lifetime is in the standard unit ns
-    return hbar / float(tau / ns)
+    return hbar / float(tau / ns)  # type: ignore[no-any-return]

--- a/src/particle/particle/literals.py
+++ b/src/particle/particle/literals.py
@@ -28,20 +28,22 @@ List of available/defined literals:
 {0}
 """
 
+from typing import List
+
 from ..shared_literals import common_particles
-from .particle import Particle, ParticleNotFound
+from .particle import Particle
+
+
+def __dir__() -> List[str]:
+    return list(common_particles)
+
 
 for item in common_particles:
     locals()[item] = Particle.from_pdgid(common_particles[item])
 
 
 __doc = "".join(
-    "  {item!s} = Particle.from_pdgid({pdgid})\n".format(
-        item=item, pdgid=common_particles[item]
-    )
+    f"  {item} = Particle.from_pdgid({common_particles[item]})\n"
     for item in common_particles
 )
 __doc__ = __doc__.format(__doc)
-
-
-del Particle, ParticleNotFound, common_particles, item

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -8,7 +8,6 @@
 import csv
 from copy import copy
 from functools import total_ordering
-from importlib.abc import Traversable
 from typing import (
     Any,
     Callable,
@@ -32,7 +31,7 @@ from .. import data
 from ..converters.evtgen import EvtGenName2PDGIDBiMap
 from ..pdgid import PDGID, is_valid
 from ..pdgid.functions import Location, _digit
-from ..typing import HasOpen, HasRead, StringOrIO
+from ..typing import HasOpen, HasRead, StringOrIO, Traversable
 from .enums import (
     Charge,
     Charge_mapping,

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -1242,9 +1242,9 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         if mat["family"]:
             if "_" in mat["family"]:
                 mat["family"] = mat["family"].strip("_")
-            name += f"({mat['family']})"
+            name += f'({mat["family"]})'
         if mat["state"]:
-            name += f"({mat['state']})"
+            name += f'({mat["state"]})'
 
         if "prime" in mat and mat["prime"]:
             name += "'"
@@ -1255,7 +1255,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         if mat["state"] is not None:
             kw["J"] = float(mat["state"])
 
-        maxname = name + f"({mat['mass']})" if mat["mass"] else name
+        maxname = name + f'({mat["mass"]})' if mat["mass"] else name
         if "charge" in mat and mat["charge"] is not None:
             kw["three_charge"] = Charge_mapping[mat["charge"]]
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -25,7 +25,7 @@ from typing import (
 
 # External dependencies
 import attr
-from hepunits.constants import c_light  # type: ignore[attr-defined]
+from hepunits.constants import c_light
 
 from .. import data
 from ..converters.evtgen import EvtGenName2PDGIDBiMap

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -125,13 +125,11 @@ def greek_letter_name_to_unicode(letter: str) -> str:
     Omega -> Ω
     omega -> ω
     """
+    case = "SMALL" if letter == letter.lower() else "CAPITAL"
+    name = letter.upper()
+
     try:
-        return unicodedata.lookup(
-            "GREEK {case} LETTER {name}".format(
-                case="SMALL" if letter == letter.lower() else "CAPITAL",
-                name=letter.upper(),
-            )
-        )
+        return unicodedata.lookup(f"GREEK {case} LETTER {name}")
     except KeyError:  # Unicodedata library uses "lamda" for "lambda", so that's an obvious miss
         return letter
 

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -711,9 +711,7 @@ def j_spin(pdgid: PDGID_TYPE) -> Optional[int]:
 def J(pdgid: PDGID_TYPE) -> Optional[float]:
     """Returns the total spin J."""
     value = j_spin(pdgid)
-    return (
-        (value - 1) / 2 if value is not None else value
-    )  # This works due to the Python 3 style division
+    return (value - 1) / 2 if value is not None else value
 
 
 def S(pdgid: PDGID_TYPE) -> Optional[int]:

--- a/src/particle/pdgid/literals.py
+++ b/src/particle/pdgid/literals.py
@@ -28,9 +28,15 @@ List of available/defined literals:
 {0}
 """
 
+from typing import List
 
 from ..shared_literals import common_particles
 from .pdgid import PDGID
+
+
+def __dir__() -> List[str]:
+    return list(common_particles)
+
 
 for item in common_particles:
     locals()[item] = PDGID(common_particles[item])
@@ -40,5 +46,3 @@ __doc = "".join(
     f"  {item!s} = PDGID({common_particles[item]})\n" for item in common_particles
 )
 __doc__ = __doc__.format(__doc)
-
-del PDGID, common_particles, item

--- a/src/particle/typing.py
+++ b/src/particle/typing.py
@@ -11,7 +11,10 @@ if sys.version_info < (3, 8):
 else:
     from typing import Protocol, runtime_checkable
 
-from typing import Any
+from importlib.abc import Traversable
+from typing import Any, TextIO, Union
+
+StringOrIO = Union[Traversable, str, TextIO]
 
 
 @runtime_checkable

--- a/src/particle/typing.py
+++ b/src/particle/typing.py
@@ -11,8 +11,22 @@ if sys.version_info < (3, 8):
 else:
     from typing import Protocol, runtime_checkable
 
-from importlib.abc import Traversable
+if sys.version_info < (3, 9):
+    from importlib_resources.abc import Traversable
+else:
+    from importlib.abc import Traversable
+
 from typing import Any, TextIO, Union
+
+__all__ = (
+    "Protocol",
+    "runtime_checkable",
+    "Traversable",
+    "StringOrIO",
+    "HasOpen",
+    "HasRead",
+)
+
 
 StringOrIO = Union[Traversable, str, TextIO]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
-# Backport needed if Python 2 is used
 from enum import IntEnum
 
 import pytest


### PR DESCRIPTION
This finishes the typing and uses f-strings everywhere reasonable. Some `type: ignore`'s will go away after the next release of HEPUnits. Some minor polish continuing the removal of Python 2.

- fix(types): full static type checking
- style: switch remaining format strings to f-strings
