### PR TITLE
fix: drop python 2 tags from our wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,6 @@ test =
 [options.package_data]
 * = *.csv, *.fwf, *.mcd, *.py.typed
 
-
 [tool:pytest]
 testpaths =
     tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,8 +73,6 @@ test =
 [options.package_data]
 * = *.csv, *.fwf, *.mcd, *.py.typed
 
-[bdist_wheel]
-universal = 1
 
 [tool:pytest]
 testpaths =


### PR DESCRIPTION
Since #389 doesn't seem like it can go in, here's the most important change. (I'd consider removing a dependency we aren't using and that has broken our ability to run on pyodide 0.19.0 high priority too, and I asked for it to be removed in February...)