### PR TITLE
fix: bump black to 22.3.0 due to click 8.1 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black-jupyter
 


### PR DESCRIPTION
See https://github.com/psf/black/issues/2964 for details.

Committed via https://github.com/asottile/all-repos