### PR TITLE
feat: drop Python 3.6, add 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v4
@@ -29,15 +29,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         include:
-          - {os: macos-latest, python-version: '3.6'}
-          - {os: macos-latest, python-version: '3.10'}
+          - {os: macos-latest, python-version: '3.7'}
+          - {os: macos-latest, python-version: '3.11-dev'}
           - {os: windows-latest, python-version: '3.7'}
-          - {os: windows-latest, python-version: '3.9'}
+          - {os: windows-latest, python-version: '3.11-dev'}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -55,14 +55,14 @@ jobs:
       run: python -m pytest ./tests --doctest-modules --cov=src/particle --cov-report=xml
 
     - name: Test coverage with Codecov
-      if: "runner.os != 'Windows' && matrix.python-version != 3.6 && matrix.python-version != 3.7"
+      if: "runner.os != 'Windows' && matrix.python-version != 3.7"
       uses: codecov/codecov-action@v3
 
   notebooks:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -84,11 +84,11 @@ jobs:
     name: ZipApp
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - uses: excitedleigh/setup-nox@main
+    - uses: wntrblm/nox@2022.8.7
 
     - name: Make ZipApp
       run: nox -s zipapp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,13 @@ repos:
   rev: v2.0.0
   hooks:
   - id: setup-cfg-fmt
+    args: [--include-version-classifiers, --max-py-version=3.11]
 
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.38.2
   hooks:
   - id: pyupgrade
-    args: ["--py36-plus"]
+    args: ["--py37-plus"]
 
 - repo: https://github.com/mgedmin/check-manifest
   rev: "0.48"
@@ -74,3 +75,10 @@ repos:
   - id: rst-backticks
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
+
+- repo: https://github.com/hadialqattan/pycln
+  rev: "v2.1.1"
+  hooks:
+    - id: pycln
+      args: [--all]
+      stages: [manual]

--- a/admin/dump_pdgid_to_lhcb.py
+++ b/admin/dump_pdgid_to_lhcb.py
@@ -5,6 +5,8 @@
 # or https://github.com/scikit-hep/particle for details.
 """This script generates the PDGID<->LHCb name mapping using the table from the LHCb DDDB package."""
 
+from __future__ import annotations
+
 import csv
 import datetime as dt
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import nox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ ignore = [
 
 [tool.isort]
 profile = "black"
+add_imports = ["from __future__ import annotations"]
 
 [tool.mypy]
 warn_unused_configs = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     hepunits>=2.0.0
     importlib-resources>=2.0;python_version<"3.9"
     typing-extensions;python_version<"3.8"
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,11 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
 keywords =
     HEP

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 from setuptools import setup
 
 setup()

--- a/src/particle/__init__.py
+++ b/src/particle/__init__.py
@@ -4,8 +4,9 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 import sys
-from typing import Tuple
 
 # Direct access to other ID classes
 from .geant import Geant3ID
@@ -47,5 +48,5 @@ __all__ = (
 )
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__

--- a/src/particle/__main__.py
+++ b/src/particle/__main__.py
@@ -5,6 +5,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 import argparse
 import sys
 

--- a/src/particle/converters/__init__.py
+++ b/src/particle/converters/__init__.py
@@ -4,7 +4,7 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
-from typing import Tuple
+from __future__ import annotations
 
 from .evtgen import EvtGen2PDGNameMap, EvtGenName2PDGIDBiMap, PDG2EvtGenNameMap
 from .geant import Geant2PDGIDBiMap
@@ -19,5 +19,5 @@ __all__ = (
 )
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__

--- a/src/particle/converters/bimap.py
+++ b/src/particle/converters/bimap.py
@@ -4,23 +4,12 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 import csv
 import sys
 from collections.abc import Mapping
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Iterator,
-    Optional,
-    TextIO,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, Generic, Iterator, TextIO, TypeVar, Union, overload
 
 from .. import data
 from ..exceptions import MatchingIDNotFound
@@ -35,10 +24,10 @@ B_conv = Callable[[str], Union[B, int]]
 class BiMap(Generic[A, B]):
     def __init__(
         self,
-        class_A: Type[A],
-        class_B: Type[B],
-        converters: Tuple[A_conv, B_conv] = (int, int),  # type: ignore[type-arg]
-        filename: Optional[StringOrIO] = None,
+        class_A: type[A],
+        class_B: type[B],
+        converters: tuple[A_conv, B_conv] = (int, int),  # type: ignore[type-arg]
+        filename: StringOrIO | None = None,
     ) -> None:
         """
         Bi-bidirectional map class.
@@ -80,8 +69,8 @@ class BiMap(Generic[A, B]):
         >>> bimap = BiMap(PDGID, PythiaID, filename=filename)
         """
 
-        self.class_A: Type[A] = class_A
-        self.class_B: Type[B] = class_B
+        self.class_A: type[A] = class_A
+        self.class_B: type[B] = class_B
 
         name_A = self.class_A.__name__.upper()
         name_B = self.class_B.__name__.upper()
@@ -147,9 +136,9 @@ class BiMap(Generic[A, B]):
 def DirectionalMaps(
     name_A: str,
     name_B: str,
-    converters: Tuple[Callable[[str], str], Callable[[str], str]] = (str, str),
-    filename: Optional[StringOrIO] = None,
-) -> Tuple["DirectionalMap", "DirectionalMap"]:
+    converters: tuple[Callable[[str], str], Callable[[str], str]] = (str, str),
+    filename: StringOrIO | None = None,
+) -> tuple[DirectionalMap, DirectionalMap]:
     """
     Directional map class providing a to and from mapping.
 
@@ -225,7 +214,7 @@ else:
 
 
 class DirectionalMap(StrStrMapping):
-    def __init__(self, name_A: str, name_B: str, map: Dict[str, str]) -> None:
+    def __init__(self, name_A: str, name_B: str, map: dict[str, str]) -> None:
         """
         Directional map class providing a A -> B mapping.
 

--- a/src/particle/converters/evtgen.py
+++ b/src/particle/converters/evtgen.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from .. import data
 from ..pdgid import PDGID
 from .bimap import BiMap, DirectionalMaps

--- a/src/particle/converters/geant.py
+++ b/src/particle/converters/geant.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from ..geant import Geant3ID
 from ..pdgid import PDGID
 from .bimap import BiMap

--- a/src/particle/converters/pythia.py
+++ b/src/particle/converters/pythia.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from ..pdgid import PDGID
 from ..pythia import PythiaID
 from .bimap import BiMap

--- a/src/particle/data/__init__.py
+++ b/src/particle/data/__init__.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import sys
 
 if sys.version_info < (3, 9):

--- a/src/particle/exceptions.py
+++ b/src/particle/exceptions.py
@@ -4,5 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
+
 class MatchingIDNotFound(ValueError):
     pass

--- a/src/particle/geant/__init__.py
+++ b/src/particle/geant/__init__.py
@@ -4,12 +4,12 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
-from typing import Tuple
+from __future__ import annotations
 
 from .geant3id import Geant3ID
 
 __all__ = ("Geant3ID",)
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__

--- a/src/particle/geant/geant3id.py
+++ b/src/particle/geant/geant3id.py
@@ -13,8 +13,10 @@ follows the PDG rules, hence uses the standard PDG IDs.
 """
 
 
+from __future__ import annotations
+
 import csv
-from typing import Type, TypeVar
+from typing import TypeVar
 
 from .. import data
 from ..exceptions import MatchingIDNotFound
@@ -49,7 +51,7 @@ class Geant3ID(int):
     __slots__ = ()  # Keep PythiaID a slots based class
 
     @classmethod
-    def from_pdgid(cls: Type[Self], pdgid: int) -> Self:
+    def from_pdgid(cls: type[Self], pdgid: int) -> Self:
         """
         Constructor from a PDGID.
         """

--- a/src/particle/lhcb/__init__.py
+++ b/src/particle/lhcb/__init__.py
@@ -3,7 +3,7 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
-from typing import Tuple
+from __future__ import annotations
 
 from .converters import LHCbName2PDGIDBiMap
 from .functions import from_lhcb_name, to_lhcb_name
@@ -15,5 +15,5 @@ __all__ = (
 )
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__

--- a/src/particle/lhcb/converters.py
+++ b/src/particle/lhcb/converters.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 from ..converters.bimap import BiMap
 from ..pdgid import PDGID
 from . import data

--- a/src/particle/lhcb/data/__init__.py
+++ b/src/particle/lhcb/data/__init__.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import sys
 
 if sys.version_info < (3, 9):

--- a/src/particle/lhcb/functions.py
+++ b/src/particle/lhcb/functions.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 from ..particle import Particle
 from .converters import LHCbName2PDGIDBiMap
 

--- a/src/particle/particle/__init__.py
+++ b/src/particle/particle/__init__.py
@@ -4,7 +4,7 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
-from typing import Tuple
+from __future__ import annotations
 
 from .enums import Charge, Inv, Parity, SpinType, Status
 from .kinematics import lifetime_to_width, width_to_lifetime
@@ -28,5 +28,5 @@ __all__ = (
 )
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__

--- a/src/particle/particle/convert.py
+++ b/src/particle/particle/convert.py
@@ -50,10 +50,12 @@ When you are done, you can save one or more of the tables:
 
 """
 
+from __future__ import annotations
+
 import os
 from datetime import date
 from io import StringIO
-from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Tuple, TypeVar
+from typing import Any, Callable, Iterable, TextIO, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -82,7 +84,7 @@ __all__ = (
 )
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__
 
 
@@ -144,7 +146,7 @@ def get_from_pdg_extended(
     """
     "Read a file, plus a list of LaTeX files, to produce a pandas DataFrame with particle information"
 
-    def unmap(mapping: Dict[str, T]) -> Callable[[str], T]:
+    def unmap(mapping: dict[str, T]) -> Callable[[str], T]:
         return lambda x: mapping[x.strip()]
 
     # Convert each column from text to appropriate data type
@@ -435,8 +437,8 @@ def main(version: str, year: str) -> None:
     produce_files(particle2008, particlenew, version, year)
 
 
-def convert(version: str, output: str, fwf: str, latex: Optional[str] = None) -> None:
-    latexes: List[StringOrIO] = [data.basepath / "pdgid_to_latexname.csv"]
+def convert(version: str, output: str, fwf: str, latex: str | None = None) -> None:
+    latexes: list[StringOrIO] = [data.basepath / "pdgid_to_latexname.csv"]
     if latex:
         latexes.append(latex)
     table = get_from_pdg_extended(fwf, latexes)

--- a/src/particle/particle/enums.py
+++ b/src/particle/particle/enums.py
@@ -8,6 +8,8 @@ Collection of enums to help characterising particle properties
 Examples are charge, spin and parity.
 """
 
+from __future__ import annotations
+
 from enum import IntEnum
 
 

--- a/src/particle/particle/kinematics.py
+++ b/src/particle/particle/kinematics.py
@@ -8,6 +8,8 @@ Functions relevant to particle kinematics.
 """
 
 
+from __future__ import annotations
+
 from hepunits.constants import hbar
 from hepunits.units import MeV, ns
 

--- a/src/particle/particle/literals.py
+++ b/src/particle/particle/literals.py
@@ -28,13 +28,13 @@ List of available/defined literals:
 {0}
 """
 
-from typing import List
+from __future__ import annotations
 
 from ..shared_literals import common_particles
 from .particle import Particle
 
 
-def __dir__() -> List[str]:
+def __dir__() -> list[str]:
     return list(common_particles)
 
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -4,25 +4,13 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 # Python standard library
 import csv
 from copy import copy
 from functools import total_ordering
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    SupportsInt,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Iterable, Iterator, Sequence, SupportsInt, TypeVar
 
 # External dependencies
 import attr
@@ -50,7 +38,7 @@ from .utilities import latex_to_html_name, programmatic_name, str_with_unc
 __all__ = ("Particle", "ParticleNotFound", "InvalidParticle")
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__
 
 
@@ -62,8 +50,8 @@ class InvalidParticle(RuntimeError):
     pass
 
 
-def _isospin_converter(isospin: str) -> Optional[float]:
-    vals: Dict[Optional[str], Optional[float]] = {
+def _isospin_converter(isospin: str) -> float | None:
+    vals: dict[str | None, float | None] = {
         "0": 0.0,
         "1/2": 0.5,
         "1": 1.0,
@@ -72,13 +60,13 @@ def _isospin_converter(isospin: str) -> Optional[float]:
     return vals.get(isospin)
 
 
-def _none_or_positive_converter(value: float) -> Optional[float]:
+def _none_or_positive_converter(value: float) -> float | None:
     return None if value < 0 else value
 
 
 # These are needed to trick attrs typing
-minus_one: Optional[float] = -1.0
-none_float: Optional[float] = None
+minus_one: float | None = -1.0
+none_float: float | None = None
 
 
 Self = TypeVar("Self", bound="Particle")
@@ -192,22 +180,18 @@ class Particle:
 
     pdgid: PDGID = attr.ib(converter=PDGID)
     pdg_name: str = attr.ib()
-    mass: Optional[float] = attr.ib(minus_one, converter=_none_or_positive_converter)
-    mass_upper: Optional[float] = attr.ib(
+    mass: float | None = attr.ib(minus_one, converter=_none_or_positive_converter)
+    mass_upper: float | None = attr.ib(minus_one, converter=_none_or_positive_converter)
+    mass_lower: float | None = attr.ib(minus_one, converter=_none_or_positive_converter)
+    width: float | None = attr.ib(minus_one, converter=_none_or_positive_converter)
+    width_upper: float | None = attr.ib(
         minus_one, converter=_none_or_positive_converter
     )
-    mass_lower: Optional[float] = attr.ib(
+    width_lower: float | None = attr.ib(
         minus_one, converter=_none_or_positive_converter
     )
-    width: Optional[float] = attr.ib(minus_one, converter=_none_or_positive_converter)
-    width_upper: Optional[float] = attr.ib(
-        minus_one, converter=_none_or_positive_converter
-    )
-    width_lower: Optional[float] = attr.ib(
-        minus_one, converter=_none_or_positive_converter
-    )
-    _three_charge: Optional[Charge] = attr.ib(Charge.u, converter=Charge)  # charge * 3
-    I: Optional[float] = attr.ib(none_float, converter=_isospin_converter)  # noqa: E741
+    _three_charge: Charge | None = attr.ib(Charge.u, converter=Charge)  # charge * 3
+    I: float | None = attr.ib(none_float, converter=_isospin_converter)  # noqa: E741
     # J = attr.ib(None)  # Total angular momentum
     G = attr.ib(Parity.u, converter=Parity)  # Parity: '', +, -, or ?
     P = attr.ib(Parity.u, converter=Parity)  # Space parity
@@ -224,16 +208,16 @@ class Particle:
         return f'<{self.__class__.__name__}: name="{self}", pdgid={int(self.pdgid)}, mass={self._str_mass()}>'
 
     # Ordered loaded table of entries
-    _table: Optional[List["Particle"]] = None
+    _table: list[Particle] | None = None
 
     # Hash optimized table of particles
-    _hash_table: Optional[Dict[int, "Particle"]] = None
+    _hash_table: dict[int, Particle] | None = None
 
     # Names of loaded tables
-    _table_names: Optional[List[str]] = None
+    _table_names: list[str] | None = None
 
     @classmethod
-    def table_names(cls) -> Tuple[str, ...]:
+    def table_names(cls) -> tuple[str, ...]:
         """
         Return the list of names loaded.
 
@@ -261,7 +245,7 @@ class Particle:
         return cls._table is not None
 
     @classmethod
-    def all(cls: Type[Self]) -> List[Self]:
+    def all(cls: type[Self]) -> list[Self]:
         """
         Access, hence get hold of, the internal particle data CSV table,
         loading it from the default location if no table has yet been loaded.
@@ -278,10 +262,10 @@ class Particle:
         exclusive_fields: Iterable[str] = (),
         exclude_fields: Iterable[str] = (),
         n_rows: int = -1,
-        filter_fn: Optional[Callable[["Particle"], bool]] = None,
-        particle: Optional[bool] = None,
+        filter_fn: Callable[[Particle], bool] | None = None,
+        particle: bool | None = None,
         **search_terms: Any,
-    ) -> Sequence[Sequence[Union[bool, int, float, str]]]:
+    ) -> Sequence[Sequence[bool | int | float | str]]:
         """
         Render a search (via `findall`) on the internal particle data CSV table
         as a `list`, loading the table from the default location if no table has yet been loaded.
@@ -422,7 +406,7 @@ class Particle:
     @classmethod
     def to_dict(
         cls, *args: Any, **kwargs: Any
-    ) -> Dict[str, Tuple[Union[bool, int, str, float], ...]]:
+    ) -> dict[str, tuple[bool | int | str | float, ...]]:
         """
         Render a search (via `findall`) on the internal particle data CSV table
         as a `dict`, loading the table from the default location if no table has yet been loaded.
@@ -535,9 +519,9 @@ class Particle:
     @classmethod
     def load_table(
         cls,
-        filename: Optional[StringOrIO] = None,
+        filename: StringOrIO | None = None,
         append: bool = False,
-        _name: Optional[str] = None,
+        _name: str | None = None,
     ) -> None:
         """
         Load a particle data CSV table. Optionally append to the existing data already loaded if append=True.
@@ -616,7 +600,7 @@ class Particle:
 
     # The following __le__ and __eq__ needed for total ordering (sort, etc)
 
-    def __lt__(self, other: Union["Particle", int]) -> bool:
+    def __lt__(self, other: Particle | int) -> bool:
         # Sort by absolute particle numbers
         # The positive one should come first
         if isinstance(other, Particle):
@@ -648,7 +632,7 @@ class Particle:
         return self.pdgid.J  # type: ignore[no-any-return]
 
     @property
-    def L(self) -> Optional[int]:
+    def L(self) -> int | None:
         """
         The orbital angular momentum L quantum number (None if not a meson).
 
@@ -658,7 +642,7 @@ class Particle:
         return self.pdgid.L  # type: ignore[no-any-return]
 
     @property
-    def S(self) -> Optional[int]:
+    def S(self) -> int | None:
         """
         The spin S quantum number (None if not a meson).
 
@@ -668,7 +652,7 @@ class Particle:
         return self.pdgid.S  # type: ignore[no-any-return]
 
     @property
-    def charge(self) -> Optional[float]:
+    def charge(self) -> float | None:
         """
         The particle charge, in units of the positron charge.
 
@@ -681,7 +665,7 @@ class Particle:
         return self.three_charge / 3 if self.three_charge is not None else None
 
     @property
-    def three_charge(self) -> Optional[int]:
+    def three_charge(self) -> int | None:
         "Three times the particle charge (charge * 3), in units of the positron charge."
         if not self.pdgid.is_nucleus:
             # Return int(...) not to return the actual enum Charge
@@ -694,7 +678,7 @@ class Particle:
             return self.pdgid.three_charge  # type: ignore[no-any-return]
 
     @property
-    def lifetime(self) -> Optional[float]:
+    def lifetime(self) -> float | None:
         """
         The particle lifetime, in nanoseconds.
 
@@ -703,7 +687,7 @@ class Particle:
         return width_to_lifetime(self.width) if self.width is not None else None
 
     @property
-    def ctau(self) -> Optional[float]:
+    def ctau(self) -> float | None:
         """
         The particle c*tau, in millimeters.
 
@@ -970,12 +954,12 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         return latex_to_html_name(self.latex_name)
 
     @classmethod
-    def empty(cls: Type[Self]) -> Self:
+    def empty(cls: type[Self]) -> Self:
         "Make a new empty particle."
         return cls(0, "Unknown", anti_flag=Inv.Same)
 
     @classmethod
-    def from_pdgid(cls: Type[Self], value: SupportsInt) -> Self:
+    def from_pdgid(cls: type[Self], value: SupportsInt) -> Self:
         """
         Get a particle from a PDGID. Uses by default the package
         extended PDG data table.
@@ -1001,7 +985,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             raise ParticleNotFound(f"Could not find PDGID {value}") from None
 
     @classmethod
-    def from_name(cls: Type[Self], name: str) -> Self:
+    def from_name(cls: type[Self], name: str) -> Self:
         """
         Get a particle from its name.
 
@@ -1019,7 +1003,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             raise ParticleNotFound(f'Could not find name "{name}"') from None
 
     @classmethod
-    def from_evtgen_name(cls: Type[Self], name: str) -> Self:
+    def from_evtgen_name(cls: type[Self], name: str) -> Self:
         """
         Get a particle from an EvtGen particle name, as in .dec decay files.
 
@@ -1034,10 +1018,10 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
     @classmethod
     def finditer(
-        cls: Type[Self],
-        filter_fn: Union[Callable[["Particle"], bool], str, None] = None,
+        cls: type[Self],
+        filter_fn: Callable[[Particle], bool] | str | None = None,
         *,
-        particle: Optional[bool] = None,
+        particle: bool | None = None,
         **search_terms: Any,
     ) -> Iterator[Self]:
         """
@@ -1129,12 +1113,12 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
     @classmethod
     def findall(
-        cls: Type[Self],
-        filter_fn: Optional[Callable[["Particle"], bool]] = None,
+        cls: type[Self],
+        filter_fn: Callable[[Particle], bool] | None = None,
         *,
-        particle: Optional[bool] = None,
+        particle: bool | None = None,
         **search_terms: Any,
-    ) -> List[Self]:
+    ) -> list[Self]:
 
         """
         Search for a particle, returning a list of candidates.
@@ -1183,13 +1167,13 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         )
 
     @classmethod
-    def find(cls: Type[Self], *args: Any, **search_terms: Any) -> Self:
+    def find(cls: type[Self], *args: Any, **search_terms: Any) -> Self:
         raise AttributeError(
             "Method has been removed post versions 0.16. Please use finditer or findall instead."
         )
 
     @classmethod
-    def from_string(cls: Type[Self], name: str) -> Self:
+    def from_string(cls: type[Self], name: str) -> Self:
         "Get a particle from a PDG style name - returns the best match."
         matches = cls.from_string_list(name)
         if matches:
@@ -1198,7 +1182,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             raise ParticleNotFound(f"{name} not found in particle table")
 
     @classmethod
-    def from_string_list(cls: Type[Self], name: str) -> List[Self]:
+    def from_string_list(cls: type[Self], name: str) -> list[Self]:
         "Get a list of particles from a PDG style name."
 
         # Forcible override
@@ -1233,9 +1217,9 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             return []
 
     @classmethod
-    def _from_group_dict_list(cls: Type[Self], mat: Dict[str, Any]) -> List[Self]:
+    def _from_group_dict_list(cls: type[Self], mat: dict[str, Any]) -> list[Self]:
 
-        kw: Dict[str, Any] = {
+        kw: dict[str, Any] = {
             "particle": False
             if mat["bar"] is not None
             else True

--- a/src/particle/particle/regex.py
+++ b/src/particle/particle/regex.py
@@ -7,6 +7,8 @@
 Collection of regular expression helper utilities for the ``Particle`` class.
 """
 
+from __future__ import annotations
+
 import re
 
 getname = re.compile(

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -3,11 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import math
 import re
 import unicodedata
 from html.entities import name2codepoint
-from typing import Optional
 
 
 def programmatic_name(name: str) -> str:
@@ -34,9 +35,7 @@ def programmatic_name(name: str) -> str:
     return name.lstrip("_")
 
 
-def str_with_unc(
-    value: float, upper: Optional[float], lower: Optional[float] = None
-) -> str:
+def str_with_unc(value: float, upper: float | None, lower: float | None = None) -> str:
     """
     Utility to print out an uncertainty with different or
     identical upper/lower bounds. Nicely formats numbers using PDG rule.

--- a/src/particle/pdgid/__init__.py
+++ b/src/particle/pdgid/__init__.py
@@ -59,7 +59,7 @@ Useful definitions:
 """
 
 
-from typing import Tuple
+from __future__ import annotations
 
 from .functions import (
     A,
@@ -152,5 +152,5 @@ __all__ = (
 )
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -24,8 +24,10 @@ References
 """
 
 
+from __future__ import annotations
+
 from enum import IntEnum
-from typing import Optional, SupportsInt
+from typing import SupportsInt
 
 PDGID_TYPE = SupportsInt
 
@@ -512,7 +514,7 @@ def has_fundamental_anti(pdgid: PDGID_TYPE) -> bool:
     return False
 
 
-def charge(pdgid: PDGID_TYPE) -> Optional[float]:
+def charge(pdgid: PDGID_TYPE) -> float | None:
     """Returns the charge."""
 
     three_charge_pdgid = three_charge(pdgid)
@@ -524,7 +526,7 @@ def charge(pdgid: PDGID_TYPE) -> Optional[float]:
         return three_charge_pdgid / 30.0
 
 
-def three_charge(pdgid: PDGID_TYPE) -> Optional[int]:
+def three_charge(pdgid: PDGID_TYPE) -> int | None:
     """
     Returns 3 times the charge.
 
@@ -684,7 +686,7 @@ def three_charge(pdgid: PDGID_TYPE) -> Optional[int]:
     return charge
 
 
-def j_spin(pdgid: PDGID_TYPE) -> Optional[int]:
+def j_spin(pdgid: PDGID_TYPE) -> int | None:
     """Returns the total spin as 2J+1."""
     if not is_valid(pdgid):
         return None
@@ -708,13 +710,13 @@ def j_spin(pdgid: PDGID_TYPE) -> Optional[int]:
     return abspid(pdgid) % 10
 
 
-def J(pdgid: PDGID_TYPE) -> Optional[float]:
+def J(pdgid: PDGID_TYPE) -> float | None:
     """Returns the total spin J."""
     value = j_spin(pdgid)
     return (value - 1) / 2 if value is not None else value
 
 
-def S(pdgid: PDGID_TYPE) -> Optional[int]:
+def S(pdgid: PDGID_TYPE) -> int | None:
     """
     Returns the spin S.
 
@@ -749,7 +751,7 @@ def S(pdgid: PDGID_TYPE) -> Optional[int]:
         return 0
 
 
-def s_spin(pdgid: PDGID_TYPE) -> Optional[int]:
+def s_spin(pdgid: PDGID_TYPE) -> int | None:
     """
     Returns the spin S as 2S+1.
 
@@ -763,7 +765,7 @@ def s_spin(pdgid: PDGID_TYPE) -> Optional[int]:
     return (2 * value + 1) if value is not None else value
 
 
-def L(pdgid: PDGID_TYPE) -> Optional[int]:
+def L(pdgid: PDGID_TYPE) -> int | None:
     """
     Returns the orbital angular momentum L.
 
@@ -825,7 +827,7 @@ def L(pdgid: PDGID_TYPE) -> Optional[int]:
     return 0
 
 
-def l_spin(pdgid: PDGID_TYPE) -> Optional[int]:
+def l_spin(pdgid: PDGID_TYPE) -> int | None:
     """
     Returns the orbital angular momentum L as 2L+1.
 
@@ -839,7 +841,7 @@ def l_spin(pdgid: PDGID_TYPE) -> Optional[int]:
     return (2 * value + 1) if value is not None else value
 
 
-def A(pdgid: PDGID_TYPE) -> Optional[int]:
+def A(pdgid: PDGID_TYPE) -> int | None:
     """Returns the atomic number A if the PDG ID corresponds to a nucleus. Else it returns None."""
     # A proton can be a Hydrogen nucleus
     # A neutron can be considered as a nucleus when given the PDG ID 1000000010,
@@ -851,7 +853,7 @@ def A(pdgid: PDGID_TYPE) -> Optional[int]:
     return (abspid(pdgid) // 10) % 1000
 
 
-def Z(pdgid: PDGID_TYPE) -> Optional[int]:
+def Z(pdgid: PDGID_TYPE) -> int | None:
     """Returns the charge Z if the PDG ID corresponds to a nucleus. Else it returns None."""
     # A proton can be a Hydrogen nucleus
     if abspid(pdgid) == 2212:

--- a/src/particle/pdgid/literals.py
+++ b/src/particle/pdgid/literals.py
@@ -28,13 +28,13 @@ List of available/defined literals:
 {0}
 """
 
-from typing import List
+from __future__ import annotations
 
 from ..shared_literals import common_particles
 from .pdgid import PDGID
 
 
-def __dir__() -> List[str]:
+def __dir__() -> list[str]:
     return list(common_particles)
 
 

--- a/src/particle/pdgid/pdgid.py
+++ b/src/particle/pdgid/pdgid.py
@@ -10,6 +10,8 @@ All methods of HepPID are implemented in a Pythonic version, see the functions m
 """
 
 
+from __future__ import annotations
+
 from inspect import isfunction
 from typing import TypeVar
 

--- a/src/particle/pythia/__init__.py
+++ b/src/particle/pythia/__init__.py
@@ -4,12 +4,12 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
-from typing import Tuple
+from __future__ import annotations
 
 from .pythiaid import PythiaID
 
 __all__ = ("PythiaID",)
 
 
-def __dir__() -> Tuple[str, ...]:
+def __dir__() -> tuple[str, ...]:
     return __all__

--- a/src/particle/pythia/pythiaid.py
+++ b/src/particle/pythia/pythiaid.py
@@ -8,8 +8,10 @@ Class representing a Pythia ID.
 """
 
 
+from __future__ import annotations
+
 import csv
-from typing import Type, TypeVar
+from typing import TypeVar
 
 from .. import data
 from ..exceptions import MatchingIDNotFound
@@ -44,7 +46,7 @@ class PythiaID(int):
     __slots__ = ()  # Keep PythiaID a slots based class
 
     @classmethod
-    def from_pdgid(cls: Type[Self], pdgid: int) -> Self:
+    def from_pdgid(cls: type[Self], pdgid: int) -> Self:
         """
         Constructor from a PDGID.
         """

--- a/src/particle/shared_literals.py
+++ b/src/particle/shared_literals.py
@@ -11,6 +11,8 @@ See the particle.literals and the pdgid.literals submodules for the actually exp
 """
 
 
+from __future__ import annotations
+
 from .particle import Particle
 
 # Make aliases for all particles in the latest "database", excluding nuclei

--- a/src/particle/typing.py
+++ b/src/particle/typing.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 import sys
 
 if sys.version_info < (3, 8):

--- a/src/particle/version.pyi
+++ b/src/particle/version.pyi
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 version: str
 version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 from enum import IntEnum
 
 import pytest

--- a/tests/converters/test_maps.py
+++ b/tests/converters/test_maps.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 
 from particle import data

--- a/tests/geant/test_geant3id.py
+++ b/tests/geant/test_geant3id.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 
 from particle.exceptions import MatchingIDNotFound

--- a/tests/lhcb/test_lhcb_name.py
+++ b/tests/lhcb/test_lhcb_name.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 
 from particle import Particle

--- a/tests/particle/test_convert.py
+++ b/tests/particle/test_convert.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 
 # Requires pandas

--- a/tests/particle/test_decfilenames.py
+++ b/tests/particle/test_decfilenames.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from particle.particle import Particle, ParticleNotFound
 
 # All particle names found in DECAY.DEC

--- a/tests/particle/test_enums.py
+++ b/tests/particle/test_enums.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from particle.particle.enums import Charge, SpinType
 
 

--- a/tests/particle/test_generation.py
+++ b/tests/particle/test_generation.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 
 # Requires pandas

--- a/tests/particle/test_generation.py
+++ b/tests/particle/test_generation.py
@@ -44,8 +44,8 @@ def test_generate(tmp_path):
 
 @pytest.mark.parametrize("filename", FILES)
 def test_csv_file_duplicates(filename):
-    with data.basepath / filename as particle_data:
-        p = pd.read_csv(particle_data, comment="#")
+    particle_data = data.basepath / filename
+    p = pd.read_csv(particle_data, comment="#")
 
     duplicates = {item for item, count in Counter(p.ID).items() if count > 1}
     assert duplicates == set()
@@ -53,7 +53,7 @@ def test_csv_file_duplicates(filename):
 
 @pytest.mark.parametrize("filename", FILES)
 def test_csv_file_has_latex(filename):
-    with data.basepath / filename as particle_data:
-        p = pd.read_csv(particle_data, comment="#")
+    particle_data = data.basepath / filename
+    p = pd.read_csv(particle_data, comment="#")
 
     assert p[p.Latex == ""].empty

--- a/tests/particle/test_kinematics.py
+++ b/tests/particle/test_kinematics.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 from hepunits.constants import hbar
 from hepunits.units import GeV, MeV, ps

--- a/tests/particle/test_literals.py
+++ b/tests/particle/test_literals.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from particle import literals as lp
 
 

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 import pytest
 from hepunits import meter, second
 from pytest import approx

--- a/tests/particle/test_performance.py
+++ b/tests/particle/test_performance.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from particle import Particle, data
 
 

--- a/tests/particle/test_utilities.py
+++ b/tests/particle/test_utilities.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 
 from particle.particle.utilities import str_with_unc

--- a/tests/pdgid/test_functions.py
+++ b/tests/pdgid/test_functions.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from particle.pdgid import (
     A,
     J,

--- a/tests/pdgid/test_literals.py
+++ b/tests/pdgid/test_literals.py
@@ -4,6 +4,8 @@
 # or https://github.com/scikit-hep/particle for details.
 
 
+from __future__ import annotations
+
 from particle.pdgid import literals as lid
 
 

--- a/tests/pdgid/test_pdgid.py
+++ b/tests/pdgid/test_pdgid.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 from particle.pdgid import PDGID
 from particle.pdgid import functions as _functions
 from particle.pdgid.pdgid import _fnames

--- a/tests/pythia/test_pythiaid.py
+++ b/tests/pythia/test_pythiaid.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import pytest
 
 from particle.exceptions import MatchingIDNotFound

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,6 +3,8 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/particle for details.
 
+from __future__ import annotations
+
 import particle
 
 


### PR DESCRIPTION
- feat: drop 3.6, add 3.11
- style: run pre-commit
- tests: drop no-op use of path as context manager (deprecated in 3.11)
