### PR TITLE
Actually run doctests with pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,7 @@ jobs:
       uses: codecov/codecov-action@v3
 
     - name: Test docstrings with doctest
-      runs-on: ubuntu-latest
-      if: "matrix.python-version == 3.11"
+      if: "runner.os == 'Linux' && matrix.python-version == 3.11"
       run: python -m pytest --doctest-modules src/particle --ignore-glob="src/particle/particle/convert.py"
 
   notebooks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
       uses: codecov/codecov-action@v3
 
     - name: Test docstrings with doctest
+      runs-on: ubuntu-latest
+      if: "matrix.python-version == 3.11"
       run: python -m pytest --doctest-modules src/particle --ignore-glob="src/particle/particle/convert.py"
 
   notebooks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,14 @@ jobs:
       run: python -m pip list
 
     - name: Test package
-      run: python -m pytest ./tests --doctest-modules --cov=src/particle --cov-report=xml
+      run: python -m pytest ./tests --cov=src/particle --cov-report=xml
 
     - name: Test coverage with Codecov
       if: "runner.os != 'Windows' && matrix.python-version != 3.7"
       uses: codecov/codecov-action@v3
+
+    - name: Test docstrings with doctest
+      run: python -m pytest --doctest-modules src/particle --ignore-glob="src/particle/particle/convert.py"
 
   notebooks:
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,9 +5,10 @@ Version under preparation
 -------------------------
 
 - Data CSV files:
-    - Version 12 of package data files:
+    - Version 12 of package data files made default:
         - Information on nuclei updated based on masses taken from package `periodictable` version 1.6.1.
         - Several Corsika7 IDs corrected.
+        - Otherwise same as version 11 files.
 
 
 Version 0.21.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,10 +5,12 @@ Version under preparation
 -------------------------
 
 - Data CSV files:
-    - Version 12 of package data files made default:
-        - Information on nuclei updated based on masses taken from package `periodictable` version 1.6.1.
-        - Several Corsika7 IDs corrected.
-        - Otherwise same as version 11 files.
+  - Version 12 of package data files made default:
+    - Information on nuclei updated based on masses taken from package `periodictable` version 1.6.1.
+    - Several Corsika7 IDs corrected.
+    - Otherwise same as version 11 files.
+- Tests:
+  - Doctests run separately in the CI.
 
 
 Version 0.21.2

--- a/src/particle/corsika/corsika7id.py
+++ b/src/particle/corsika/corsika7id.py
@@ -129,7 +129,7 @@ class Corsika7ID(int):
 
         Examples
         --------
-        >>> mu_minux = Corsika7ID(6)
+        >>> mu_minus = Corsika7ID(6)
         >>> mu_minus.is_particle()
         True
         >>> mu_info = Corsika7ID(76)
@@ -201,7 +201,7 @@ class Corsika7ID(int):
         --------
         >>> Corsika7ID(6).to_pdgid()
         <PDGID: 13>
-        >>> Corsika7ID(76).to_pdgid()
+        >>> Corsika7ID(76).to_pdgid()  # doctest: +SKIP
         InvalidParticle: The Corsika7ID <Corsika7ID: 76> does not correspond to a particle and thus has no equivalent PDGID.
         """
         from ..particle.particle import InvalidParticle  # pylint: disable=C0415

--- a/src/particle/lhcb/functions.py
+++ b/src/particle/lhcb/functions.py
@@ -17,7 +17,7 @@ def to_lhcb_name(p: Particle) -> str:
     --------
     >>> p = Particle.from_pdgid(-531)
     >>> p
-    <Particle: name="B(s)~0", pdgid=-531, mass=5366.88 ± 0.14 MeV>
+    <Particle: name="B(s)~0", pdgid=-531, mass=5366.92 ± 0.10 MeV>
     >>> to_lhcb_name(p)
     'B_s~0'
     """
@@ -31,7 +31,7 @@ def from_lhcb_name(name: str) -> Particle:
     Examples
     --------
     >>> from_lhcb_name("B_s~0")
-    <Particle: name="B(s)~0", pdgid=-531, mass=5366.88 ± 0.14 MeV>
+    <Particle: name="B(s)~0", pdgid=-531, mass=5366.92 ± 0.10 MeV>
 
     Raises
     ------

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -1213,15 +1213,15 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
            >>> # Returns proton and antiproton only
            >>> Particle.findall(pdg_name='p')    # doctest: +NORMALIZE_WHITESPACE
-           [<Particle: name="p", pdgid=2212, mass=938.2720882 ± 0.000003 MeV>,
-            <Particle: name="p~", pdgid=-2212, mass=938.2720882 ± 0.000003 MeV>,
-            <Particle: name="p", pdgid=1000010010, mass=938.2720882 ± 0.000003 MeV>,
-            <Particle: name="p~", pdgid=-1000010010, mass=938.2720882 ± 0.000003 MeV>]
+           [<Particle: name="p", pdgid=2212, mass=938.2720882 ± 0.0000003 MeV>,
+            <Particle: name="p~", pdgid=-2212, mass=938.2720882 ± 0.0000003 MeV>,
+            <Particle: name="p", pdgid=1000010010, mass=938.2720882 ± 0.0000003 MeV>,
+            <Particle: name="p~", pdgid=-1000010010, mass=938.2720882 ± 0.0000003 MeV>]
 
            >>> # Returns proton only
-           >>> Particle.findall(pdg_name='p ', particle=True)    # doctest: +NORMALIZE_WHITESPACE
-           [<Particle: name="p", pdgid=2212, mass=938.2720882 ± 0.000003 MeV>,
-           <Particle: name="p", pdgid=1000010010, mass=938.2720882 ± 0.000003 MeV>]
+           >>> Particle.findall(pdg_name='p', particle=True)    # doctest: +NORMALIZE_WHITESPACE
+           [<Particle: name="p", pdgid=2212, mass=938.2720882 ± 0.0000003 MeV>,
+           <Particle: name="p", pdgid=1000010010, mass=938.2720882 ± 0.0000003 MeV>]
 
         Versatile searches require a (lambda) function as argument:
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -347,14 +347,14 @@ class Particle:
 
         >>> query_as_list = Particle.to_list(filter_fn=lambda p: p.pdgid.is_lepton and p.charge!=0, exclusive_fields=['pdgid', 'name', 'mass', 'charge'], particle=False)
         >>> print(tabulate(query_as_list, headers='firstrow', tablefmt="rst", floatfmt=".12g", numalign="decimal"))
-        =======  ======  ===============  ========
-          pdgid  name               mass    charge
-        =======  ======  ===============  ========
-            -11  e+         0.5109989461         1
-            -13  mu+      105.6583745            1
-            -15  tau+    1776.86                 1
-            -17  tau'+                           1
-        =======  ======  ===============  ========
+        =======  ======  =============  ========
+          pdgid  name             mass    charge
+        =======  ======  =============  ========
+            -11  e+         0.51099895         1
+            -13  mu+      105.6583755          1
+            -15  tau+    1776.86               1
+            -17  tau'+                         1
+        =======  ======  =============  ========
 
         >>> query_as_list = Particle.to_list(filter_fn=lambda p: p.pdgid.is_lepton, pdg_name='tau', exclusive_fields=['pdgid', 'name', 'mass', 'charge'])
         >>> print(tabulate(query_as_list, headers='firstrow'))
@@ -1213,13 +1213,13 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
            >>> # Returns proton and antiproton only
            >>> Particle.findall(pdg_name='p')    # doctest: +NORMALIZE_WHITESPACE
-           [<Particle: name="p", pdgid=2212, mass=938.272081 ± 0.000006 MeV>,
-            <Particle: name="p~", pdgid=-2212, mass=938.272081 ± 0.000006 MeV>,
-            <Particle: name="p", pdgid=1000010010, mass=938.272081 ± 0.000006 MeV>,
-            <Particle: name="p~", pdgid=-1000010010, mass=938.272081 ± 0.000006 MeV>]
+           [<Particle: name="p", pdgid=2212, mass=938.2720882 ± 0.000003 MeV>,
+            <Particle: name="p~", pdgid=-2212, mass=938.2720882 ± 0.000003 MeV>,
+            <Particle: name="p", pdgid=1000010010, mass=938.2720882 ± 0.000003 MeV>,
+            <Particle: name="p~", pdgid=-1000010010, mass=938.2720882 ± 0.000003 MeV>]
 
            >>> # Returns proton only
-           >>> Particle.findall(pdg_name='p', particle=True)    # doctest: +NORMALIZE_WHITESPACE
+           >>> Particle.findall(pdg_name='p ', particle=True)    # doctest: +NORMALIZE_WHITESPACE
            [<Particle: name="p", pdgid=2212, mass=938.272081 ± 0.000006 MeV>,
            <Particle: name="p", pdgid=1000010010, mass=938.272081 ± 0.000006 MeV>]
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -1220,8 +1220,8 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
            >>> # Returns proton only
            >>> Particle.findall(pdg_name='p ', particle=True)    # doctest: +NORMALIZE_WHITESPACE
-           [<Particle: name="p", pdgid=2212, mass=938.272081 ± 0.000006 MeV>,
-           <Particle: name="p", pdgid=1000010010, mass=938.272081 ± 0.000006 MeV>]
+           [<Particle: name="p", pdgid=2212, mass=938.2720882 ± 0.000003 MeV>,
+           <Particle: name="p", pdgid=1000010010, mass=938.2720882 ± 0.000003 MeV>]
 
         Versatile searches require a (lambda) function as argument:
 

--- a/tests/particle/test_generation.py
+++ b/tests/particle/test_generation.py
@@ -69,7 +69,7 @@ check_nucleons = (
 
 
 @pytest.mark.parametrize("id_particle,id_nucleus", check_nucleons)
-def test_nucleon_properties(id_particle,id_nucleus):
+def test_nucleon_properties(id_particle, id_nucleus):
     """
     Protons and neutrons are both available in the particles table and in the nuclei table
     under IDs 2212 and 2112, and 1000010010 and 1000000010, respectively.

--- a/tests/particle/test_generation.py
+++ b/tests/particle/test_generation.py
@@ -13,6 +13,7 @@ pd = pytest.importorskip("pandas")
 from collections import Counter
 
 from particle import data
+from particle.particle import Particle
 from particle.particle.convert import produce_files
 
 FILES = ["particle2021.csv", "particle2022.csv"]
@@ -57,3 +58,25 @@ def test_csv_file_has_latex(filename):
     p = pd.read_csv(particle_data, comment="#")
 
     assert p[p.Latex == ""].empty
+
+
+check_nucleons = (
+    (2212, 1000010010),
+    (-2212, -1000010010),
+    (2112, 1000000010),
+    (-2112, -1000000010),
+)
+
+
+@pytest.mark.parametrize("id_particle,id_nucleus", check_nucleons)
+def test_nucleon_properties(id_particle,id_nucleus):
+    """
+    Protons and neutrons are both available in the particles table and in the nuclei table
+    under IDs 2212 and 2112, and 1000010010 and 1000000010, respectively.
+    This trivial test checks most of what is likely to change between PDG updates,
+    to ensure consistency.
+    """
+    p_particle = Particle.from_pdgid(id_particle)
+    p_nucleus = Particle.from_pdgid(id_nucleus)
+
+    assert p_particle.describe() == p_nucleus.describe()

--- a/tests/particle/test_generation.py
+++ b/tests/particle/test_generation.py
@@ -79,4 +79,5 @@ def test_nucleon_properties(id_particle, id_nucleus):
     p_particle = Particle.from_pdgid(id_particle)
     p_nucleus = Particle.from_pdgid(id_nucleus)
 
-    assert p_particle.describe() == p_nucleus.describe()
+    # Trivial replacement of IDs to avoid obvious irrelevant differences
+    assert p_particle.describe().replace(f"{id_particle:<12}",f"{id_particle:<12}") == p_nucleus.describe().replace(f"{id_nucleus:<12}",f"{id_particle:<12}")


### PR DESCRIPTION
It turns out that doctests were in fact not being run. This update adds an explicit step for doctests.

With this I can see several docstrings that needed updates for PDG 2022 mass values, for example.