### PR TITLE
chore: clean up zipfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -57,11 +57,10 @@ def zipapp(session: nox.Session) -> None:
         "-m",
         "pip",
         "install",
+        "--no-compile",
         ".",
-        "attrs",
-        "hepunits",
         "importlib_resources",
-        "deprecated",
+        "typing_extensions",
         f"--target={tmpdir}",
     )
 


### PR DESCRIPTION
This was generating .pyc files for all packages; those are not needed (since they will target only one version of Python - 3.7 in this case).