### PR TITLE
Fix is_quarkonium in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ For the sake of example, quarkonia can be specified with the following user-defi
 .. code-block:: python
 
     >>> is_heavy_flavor = lambda x: has_charm(x) or has_bottom(x) or has_top(x)
-    >>> is_quarkonium = lambda x: is_meson(x) and three_charge(x)==0 and is_heavy_flavor(x).
+    >>> is_quarkonium = lambda x: is_meson(x) and is_heavy_flavor(x) and Particle.from_pdgid(x).is_self_conjugate
 
 PDG ID literals provide (``PDGID`` class) aliases for all particles loaded, with easily recognisable names.
 For example:


### PR DESCRIPTION
Closes: https://github.com/scikit-hep/particle/issues/476

This fixes the example such that we only get quarkonia 
```
>>> print ([p.quarks for p in Particle.finditer(lambda p: len(p.quarks)==2 and p.quarks[0] == p.quarks[1].swapcase())])
['cC', 'cC', 'cC', 'bB', 'bB', 'cC', 'cC', 'bB', 'bB', 'cC', 'bB', 'bB', 'cC', 'cC', 'cC', 'cC', 'bB', 'bB', 'bB', 'bB', 'bB', 'bB', 'cC', 'bB', 'cC', 'bB', 'cC']
>>> print ([p.quarks for p in Particle.finditer(lambda p: is_meson(p.pdgid) and is_heavy_flavor(p.pdgid) and p.is_self_conjugate)])
['cC', 'cC', 'cC', 'bB', 'bB', 'cC', 'cC', 'bB', 'bB', 'cC', 'bB', 'bB', 'cC', 'cC', 'cC', 'cC', 'bB', 'bB', 'bB', 'bB', 'bB', 'bB', 'cC', 'bB', 'cC', 'bB', 'cC']
```
instead of what current example produces
```
>>> print ([p.quarks for p in Particle.finditer(lambda p: is_meson(p.pdgid) and is_heavy_flavor(p.pdgid) and three_charge(p.pdgid)==0)])
['cU', 'Cu', 'cU', 'Cu', 'cU', 'Cu', 'cC', 'cC', 'cC', 'dB', 'Db', 'dB', 'Db', 'dB', 'Db', 'sB', 'Sb', 'sB', 'Sb', 'sB', 'Sb', 'bB', 'bB', 'cU', 'Cu', 'cU', 'Cu', 'cC', 'cC', 'bB', 'bB', 'cU', 'Cu', 'cC', 'bB', 'bB', 'cC', 'cC', 'cC', 'cC', 'bB', 'bB', 'bB', 'bB', 'bB', 'bB', 'cC', 'bB', 'cC', 'bB', 'cC']

```