### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ ignore = [
     "PLR",    # Design related pylint codes
     "PT013",  # Importing approx from pytest is fine
 ]
-target-version = "py37"
 src = ["src"]
 unfixable = [
   "T20",  # Removes print statements


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos