### PR TITLE
chore: modernize Ruff config, use ruff-format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
     - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pre-commit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,16 +18,13 @@ repos:
   - id: debug-statements
   - id: end-of-file-fixer
 
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.11.0
-  hooks:
-  - id: black-jupyter
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.1.6"
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
+    - id: ruff-format
+      types_or: [python, pyi, jupyter]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.7.0

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 
 |Scikit-HEP| |PyPI version| |Conda-forge version| |Zenodo DOI|
 
-|GitHub Actions Status: CI| |Code Coverage| |Code style: black|
+|GitHub Actions Status: CI| |Code Coverage|
 
 |Binder|
 
@@ -488,9 +488,6 @@ are those of the authors and do not necessarily reflect the views of the Nationa
 
 .. |Code Coverage| image:: https://codecov.io/gh/scikit-hep/particle/graph/badge.svg?branch=master
    :target: https://codecov.io/gh/scikit-hep/particle?branch=master
-
-.. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/scikit-hep/particle/master?urlpath=lab/tree/notebooks/ParticleDemo.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ warn_unused_ignores = true
 python_version = "3.9"
 files = "src"
 strict = true
-show_error_codes = true
 warn_unreachable = true
 enable_error_code = [
     "ignore-without-code",
@@ -98,6 +97,7 @@ minversion = "6.0"
 testpaths = ["tests"]
 junit_family = "xunit2"
 log_cli_level = "info"
+xfail_strict = true
 addopts = [
     "--benchmark-disable",
     "-ra",
@@ -143,9 +143,11 @@ messages_control.disable = [
 
 
 [tool.ruff]
-select = [
-    "E", "F", "W", # flake8
-    "B", "B904",   # flake8-bugbear
+src = ["src"]
+
+[tool.ruff.lint]
+extend-select = [
+    "B",            # flake8-bugbear
     "I",           # isort
     "ARG",         # flake8-unused-arguments
     "C4",          # flake8-comprehensions
@@ -163,23 +165,23 @@ select = [
     "YTT",         # flake8-2020
 ]
 ignore = [
-    "B905",
-    "E402",
-    "E501",
-    "RUF001", # Ambiguous unicode
-    "RUF002", # Ambiguous unicode docstring
-    "PLR",    # Design related pylint codes
-    "PT013",  # Importing approx from pytest is fine
-]
-src = ["src"]
-unfixable = [
-  "T20",  # Removes print statements
-  "F841", # Removes unused variables
+    "RUF001",  # Ambiguous unicode
+    "RUF002",  # Ambiguous unicode docstring
+    "PLR2004", # Magic value used in comparison
+    "PLR09",   # Too many X
+    "ISC001",  # Conflicts with the formatter
+    "E741",    # Ambiguous variable name
 ]
 isort.required-imports = ["from __future__ import annotations"]
+mccabe.max-complexity = 24
 
-[tool.ruff.mccabe]
-max-complexity = 24
-
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "src/particle/__main__.py" = ["T20"]
+"tests/**.py" = [
+    "PT013",  # Importing approx from pytest is fine
+    "E402",   # Module level import not at top of file (doesn't recognise pytest.importorskip)
+]
+
+
+[tool.repo-review]
+ignore = ["RTD"]

--- a/src/particle/__init__.py
+++ b/src/particle/__init__.py
@@ -13,7 +13,17 @@ from .geant import Geant3ID
 
 # Direct access to Particle literals
 # Direct access to Particle (the CSV file is not read until a particle is accessed)
-from .particle import InvalidParticle, Particle, ParticleNotFound, literals
+# Direct access to handy LaTeX to HTML particle name conversions
+# Direct access to kinematics functions
+from .particle import (
+    InvalidParticle,
+    Particle,
+    ParticleNotFound,
+    latex_to_html_name,
+    lifetime_to_width,
+    literals,
+    width_to_lifetime,
+)
 from .particle.enums import Charge, Inv, Parity, SpinType, Status
 
 # Direct access to PDGID and other ID classes
@@ -23,11 +33,8 @@ from .pythia import PythiaID
 # Convenient access to the version number
 from .version import version as __version__
 
+# Literals direct access
 sys.modules["particle.literals"] = literals
-
-# Direct access to handy LaTeX to HTML particle name conversions
-# Direct access to kinematics functions
-from .particle import latex_to_html_name, lifetime_to_width, width_to_lifetime
 
 __all__ = (
     "Charge",

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -194,7 +194,7 @@ class Particle:
         minus_one, converter=_none_or_positive_converter
     )
     _three_charge: Charge | None = attr.ib(Charge.u, converter=Charge)  # charge * 3
-    I: float | None = attr.ib(none_float, converter=_isospin_converter)  # noqa: E741
+    I: float | None = attr.ib(none_float, converter=_isospin_converter)
     # J = attr.ib(None)  # Total angular momentum
     G = attr.ib(Parity.u, converter=Parity)  # Parity: '', +, -, or ?
     P = attr.ib(Parity.u, converter=Parity)  # Space parity


### PR DESCRIPTION
Modernize Ruff config. ~~Waiting on the next release (which adds better Jupyter notebook support) for ruff-format.~~ (Now released)

See https://github.com/scientific-python/cookie/pull/299.