### PR TITLE
fix: replace deprecated package with Python 3.13 deprecated decorator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Test docstrings with doctest
       if: "runner.os == 'Linux' && matrix.python-version == 3.11"
-      run: python -m pytest --doctest-modules src/particle --ignore-glob="src/particle/particle/convert.py"
+      run: python -m pytest --doctest-modules src/particle --ignore=src/particle/particle/convert.py
 
   notebooks:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
   hooks:
   - id: mypy
     files: src
-    additional_dependencies: [attrs==21.4.0, hepunits>=2.2.0, importlib_resources, types-deprecated]
+    additional_dependencies: [attrs==21.4.0, hepunits>=2.2.0, importlib_resources]
     args: [--show-error-codes]
 
 - repo: https://github.com/codespell-project/codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,7 @@ dependencies = [
     "attrs>=19.2",
     "hepunits>=2.0.0",
     "importlib-resources>=2.0;python_version<\"3.9\"",
-    "typing-extensions;python_version<\"3.8\"",
-    "deprecated"
+    "typing-extensions>=4.5;python_version<\"3.13\"",
 ]
 dynamic = ["version"]
 

--- a/src/particle/_compat/typing.py
+++ b/src/particle/_compat/typing.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2018-2023, Eduardo Rodrigues and Henry Schreiner.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/particle for details.
+
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Protocol, runtime_checkable
+else:
+    from typing import Protocol, runtime_checkable
+
+if sys.version_info < (3, 9):
+    from importlib_resources.abc import Traversable
+elif sys.version_info < (3, 11):
+    from importlib.abc import Traversable
+else:
+    from importlib.resources.abc import Traversable
+
+
+__all__ = (
+    "Protocol",
+    "runtime_checkable",
+    "Traversable",
+)

--- a/src/particle/_compat/warnings.py
+++ b/src/particle/_compat/warnings.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
+else:
+    from warnings import deprecated
+
+__all__ = ["deprecated"]

--- a/src/particle/particle/convert.py
+++ b/src/particle/particle/convert.py
@@ -63,8 +63,9 @@ import numpy as np
 import pandas as pd
 
 from .. import data
+from .._compat.typing import Traversable
 from ..pdgid import PDGID, is_baryon
-from ..typing import StringOrIO, Traversable
+from ..typing import StringOrIO
 from .enums import (
     Charge,
     Charge_mapping,

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -15,14 +15,15 @@ from typing import Any, Callable, Iterable, Iterator, Sequence, SupportsInt, Typ
 
 # External dependencies
 import attr
-from deprecated import deprecated
 from hepunits.constants import c_light
 
 from .. import data
+from .._compat.typing import Traversable
+from .._compat.warnings import deprecated
 from ..converters.evtgen import EvtGenName2PDGIDBiMap
 from ..pdgid import PDGID, is_valid
 from ..pdgid.functions import Location, _digit
-from ..typing import HasOpen, HasRead, StringOrIO, Traversable
+from ..typing import HasOpen, HasRead, StringOrIO
 from .enums import (
     Charge,
     Charge_mapping,
@@ -1240,8 +1241,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
     @classmethod
     @deprecated(
-        version="0.22",
-        reason="This method is deprecated and will be removed from version 0.23.0. Use finditer or findall instead.",
+        "This method is deprecated and will be removed from version 0.23.0. Use finditer or findall instead.",
     )
     def from_string(cls: type[Self], name: str) -> Self:
         "Get a particle from a PDG style name - returns the best match."
@@ -1252,8 +1252,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
 
     @classmethod
     @deprecated(
-        version="0.22",
-        reason="This method is deprecated and will be removed from version 0.23.0. Use finditer or findall instead.",
+        "This method is deprecated and will be removed from version 0.23.0. Use finditer or findall instead.",
     )
     def from_string_list(cls: type[Self], name: str) -> list[Self]:
         "Get a list of particles from a PDG style name."

--- a/src/particle/typing.py
+++ b/src/particle/typing.py
@@ -6,24 +6,11 @@
 
 from __future__ import annotations
 
-import sys
 from typing import Any, TextIO, Union
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Protocol, runtime_checkable
-else:
-    from typing import Protocol, runtime_checkable
-
-if sys.version_info < (3, 9):
-    from importlib_resources.abc import Traversable
-else:
-    from importlib.abc import Traversable
-
+from ._compat.typing import Protocol, Traversable, runtime_checkable
 
 __all__ = (
-    "Protocol",
-    "runtime_checkable",
-    "Traversable",
     "StringOrIO",
     "HasOpen",
     "HasRead",


### PR DESCRIPTION
This is available in `typing_extensions` already and will be in CPython 3.13, and unlike the third-party package, typing tools can tell this is deprecated (mypy soon, some other typing checkers already support it).

This also enables us to start testing on 3.12 in a followup (fixes a warning importing Traversable).
