### PR TITLE
chore: add pixi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ docs/_build
 /pip-wheel-metadata
 
 *.pyz
+*.pixi

--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,9 @@ dependencies:
   - python>=3.8
   # Setting recent versions to make the conda solve faster
   - numpy>=1.16
-  - pandas>=0.24
-  - attrs>=19.0
-  - pip>=10.0
-  - jupyterlab>=1.0
+  - pandas>=1
+  - attrs>=19
+  - jupyterlab>=4
   - tabulate
-  - RISE
   - pip:
     - .

--- a/notebooks/ParticleDemo.ipynb
+++ b/notebooks/ParticleDemo.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "### Henry Schreiner and Eduardo Rodrigues\n",
     "\n",
-    "Some of the demos assume you have run `python -m pip install particle`. The demos use Python 3, though the package also supports Python 2 for now. You can [view the demo here](https://nbviewer.jupyter.org/github/scikit-hep/particle/blob/master/notebooks/ParticleDemo.ipynb) or [run it here](https://mybinder.org/v2/gh/scikit-hep/particle/master?urlpath=lab/tree/notebooks/ParticleDemo.ipynb) on Binder."
+    "Some of the demos assume you have run `python -m pip install particle` or `pixi run lab`. You can [view the demo here](https://nbviewer.jupyter.org/github/scikit-hep/particle/blob/master/notebooks/ParticleDemo.ipynb) or [run it here](https://mybinder.org/v2/gh/scikit-hep/particle/master?urlpath=lab/tree/notebooks/ParticleDemo.ipynb) on Binder."
    ]
   },
   {
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All dependencies (including the two backports) are installed inside the ZipApp, and the data lookup is handled in a zip-safe way inside particle. Python 3 is used to make the zipapp, but including the backports makes it work on Python 2 as well.\n",
+    "All dependencies (including the two backports) are installed inside the ZipApp, and the data lookup is handled in a zip-safe way inside particle.\n",
     "\n",
     "The command line mode could be enhanced to make it a useful tool in bash scripts! Stay tuned..."
    ]
@@ -655,7 +655,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -669,7 +669,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,3 +186,22 @@ mccabe.max-complexity = 24
 
 [tool.repo-review]
 ignore = ["RTD"]
+
+
+[tool.pixi.project]
+name = "particle"
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+
+[tool.pixi.pypi-dependencies]
+particle  = { path = ".", editable = true}
+
+[tool.pixi.dependencies]
+numpy = ">=1.16"
+pandas = ">=1"
+attrs = ">=19"
+jupyterlab = ">=4"
+tabulate = "*"
+
+[tool.pixi.tasks]
+lab = "jupyter lab"


### PR DESCRIPTION
This uses the new pixi 0.18 support for editable installs and pyproject.toml. I left the classic environment.yml in for Binder for now - we can remove it if binder starts supporting it. It's mostly experimental at this point, but it seems to work pretty well. I have not committed the lockfile yet since we aren't using it anywhere at the moment.
