### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          - {os: macos-latest, python-version: '3.8'}
-          - {os: macos-latest, python-version: '3.12'}
+          - {os: macos-13, python-version: '3.8'}
+          - {os: macos-13, python-version: '3.12'}
           - {os: windows-latest, python-version: '3.8'}
           - {os: windows-latest, python-version: '3.12'}
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos