### PR TITLE
Make sure neutron, proton and their anti-particles compare equal

### DIFF
--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -50,8 +50,8 @@ class InvalidParticle(RuntimeError):
     pass
 
 
-# the neutron, proton and their anti-particles have two possible pdgid representations
-# a) the bag of quarks b) the nucleus
+# The proton and the neutron (and their anti-particles) have two possible PDG ID representations,
+# a) a particle ("bag of quarks") or b) a nucleus.
 _NON_UNIQUE_PDGIDS = {
     2112: 1000000010,
     2212: 1000010010,
@@ -626,6 +626,12 @@ class Particle:
         return int(self.pdgid) < other
 
     def __eq__(self, other: object) -> bool:
+    """
+    Note
+    ----
+    Ensure the comparison also works for the special cases of the proton and the neutron,
+    which have two PDG ID representations as particles or nuclei."""
+    """
         if isinstance(other, Particle):
             other = other.pdgid
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -1117,7 +1117,10 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
         pdgid = int(1e9 + l_strange * 1e5 + z * 1e4 + a * 10 + i)
 
         if anti:
-            return cls.from_pdgid(-pdgid)
+            pdgid = -pdgid
+
+        # replace nucleon ids of single hadrons with quark version
+        pdgid = _PREFERRED_PDGID.get(pdgid, pdgid)
 
         return cls.from_pdgid(pdgid)
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -627,6 +627,8 @@ class Particle:
 
     def __eq__(self, other: object) -> bool:
     """
+    Compare with another Particle instance based in PDG IDs.
+
     Note
     ----
     Ensure the comparison also works for the special cases of the proton and the neutron,

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -626,14 +626,14 @@ class Particle:
         return int(self.pdgid) < other
 
     def __eq__(self, other: object) -> bool:
-    """
-    Compare with another Particle instance based on PDG IDs.
+        """
+        Compare with another Particle instance based on PDG IDs.
 
-    Note
-    ----
-    Ensure the comparison also works for the special cases of the proton and the neutron,
-    which have two PDG ID representations as particles or nuclei.
-    """
+        Note
+        ----
+        Ensure the comparison also works for the special cases of the proton and the neutron,
+        which have two PDG ID representations as particles or nuclei.
+        """
         if isinstance(other, Particle):
             other = other.pdgid
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -627,12 +627,12 @@ class Particle:
 
     def __eq__(self, other: object) -> bool:
     """
-    Compare with another Particle instance based in PDG IDs.
+    Compare with another Particle instance based on PDG IDs.
 
     Note
     ----
     Ensure the comparison also works for the special cases of the proton and the neutron,
-    which have two PDG ID representations as particles or nuclei."""
+    which have two PDG ID representations as particles or nuclei.
     """
         if isinstance(other, Particle):
             other = other.pdgid

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -711,10 +711,10 @@ def test_evtgen_name(name, pid):  # noqa: ARG001
 @pytest.mark.parametrize(
     ("pdgid1", "pdgid2"),
     [
-        pytest.param(2212, 1000010010, id="proton"),
-        pytest.param(2112, 1000000010, id="neutron"),
-        pytest.param(-2212, -1000010010, id="anti-proton"),
-        pytest.param(-2112, -1000000010, id="anti-neutron"),
+        pytest.param(2212, 1000010010, id="p"),
+        pytest.param(2112, 1000000010, id="n"),
+        pytest.param(-2212, -1000010010, id="p~"),
+        pytest.param(-2112, -1000000010, id="n~"),
     ],
 )
 def test_eq_non_unique_pdgids(pdgid1, pdgid2):
@@ -725,3 +725,20 @@ def test_eq_non_unique_pdgids(pdgid1, pdgid2):
     assert p1.pdgid != p2.pdgid
     assert p1 == p2
     assert hash(p1) == hash(p2)
+
+
+@pytest.mark.parametrize(
+    ("name", "pdgid"),
+    [
+        pytest.param("p", 2212, id="p"),
+        pytest.param("n", 2112, id="n"),
+        pytest.param("p~", -2212, id="p~"),
+        pytest.param("n~", -2112, id="n~"),
+    ],
+)
+def test_from_name_non_unique_pdgids(name, pdgid):
+    """The proton and the neutron have two pdgid representations, make sure they still compare equal"""
+
+    p = Particle.from_name(name)
+    assert p.name == name
+    assert p.pdgid == pdgid

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -175,6 +175,7 @@ def test_from_nucleus_info_special_cases():
     """
     The proton and the neutron should return the preferred quark representation
     rather than the representation as a nucleus.
+    """
     assert Particle.from_nucleus_info(a=1, z=1).pdgid == 2212
     assert Particle.from_nucleus_info(a=1, z=0).pdgid == 2112
 

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -706,3 +706,22 @@ def test_decfile_style_names(name, pid):
 @pytest.mark.parametrize(("name", "pid"), decfile_style_names)
 def test_evtgen_name(name, pid):  # noqa: ARG001
     assert Particle.from_evtgen_name(name).evtgen_name == name
+
+
+@pytest.mark.parametrize(
+    ("pdgid1", "pdgid2"),
+    [
+        pytest.param(2212, 1000010010, id="proton"),
+        pytest.param(2112, 1000000010, id="neutron"),
+        pytest.param(-2212, -1000010010, id="anti-proton"),
+        pytest.param(-2112, -1000000010, id="anti-neutron"),
+    ],
+)
+def test_eq_non_unique_pdgids(pdgid1, pdgid2):
+    """The proton and the neutron have two pdgid representations, make sure they still compare equal"""
+
+    p1 = Particle.from_pdgid(pdgid1)
+    p2 = Particle.from_pdgid(pdgid2)
+    assert p1.pdgid != p2.pdgid
+    assert p1 == p2
+    assert hash(p1) == hash(p2)

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -171,6 +171,7 @@ def test_from_nucleus_info():
     p = Particle.from_nucleus_info(1, 2, anti=True)
     assert p.pdgid == -1000010020
 
+
 def test_from_nucleus_info_special_cases():
     """
     The proton and the neutron should return the preferred quark representation

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -171,7 +171,10 @@ def test_from_nucleus_info():
     p = Particle.from_nucleus_info(1, 2, anti=True)
     assert p.pdgid == -1000010020
 
-    # proton and neutron should return the preferred quark representation
+def test_from_nucleus_info_special_cases():
+    """
+    The proton and the neutron should return the preferred quark representation
+    rather than the representation as a nucleus.
     assert Particle.from_nucleus_info(a=1, z=1).pdgid == 2212
     assert Particle.from_nucleus_info(a=1, z=0).pdgid == 2112
 
@@ -722,7 +725,7 @@ def test_evtgen_name(name, pid):  # noqa: ARG001
     ],
 )
 def test_eq_non_unique_pdgids(pdgid1, pdgid2):
-    """The proton and the neutron have two pdgid representations, make sure they still compare equal"""
+    """The proton and the neutron have two PDG ID representations. Make sure they still compare equal."""
 
     p1 = Particle.from_pdgid(pdgid1)
     p2 = Particle.from_pdgid(pdgid2)
@@ -742,7 +745,10 @@ def test_eq_non_unique_pdgids(pdgid1, pdgid2):
     ],
 )
 def test_from_name_non_unique_pdgids(name, pdgid):
-    """Test that Particle.fromn_name works for p and n, returning the preferred version"""
+    """
+    Test that Particle.from_name works for p and n, returning the preferred quark representation
+     rather than the representation as a nucleus.
+     """
 
     p = Particle.from_name(name)
     assert p.name == name

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -171,6 +171,10 @@ def test_from_nucleus_info():
     p = Particle.from_nucleus_info(1, 2, anti=True)
     assert p.pdgid == -1000010020
 
+    # proton and neutron should return the preferred quark representation
+    assert Particle.from_nucleus_info(a=1, z=1).pdgid == 2212
+    assert Particle.from_nucleus_info(a=1, z=0).pdgid == 2112
+
 
 def test_from_nucleus_info_ParticleNotFound():
     with pytest.raises(ParticleNotFound):

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -742,3 +742,25 @@ def test_from_name_non_unique_pdgids(name, pdgid):
     p = Particle.from_name(name)
     assert p.name == name
     assert p.pdgid == pdgid
+
+
+@pytest.mark.parametrize("sign", [1, -1])
+def test_particle_hash(sign):
+    proton1 = Particle.from_pdgid(sign * 2212)
+    proton2 = Particle.from_pdgid(sign * 1000010010)
+    neutron1 = Particle.from_pdgid(sign * 2112)
+    neutron2 = Particle.from_pdgid(sign * 1000000010)
+
+    s1 = {proton1, neutron1}
+
+    assert proton1 in s1
+    assert proton2 in s1
+    assert neutron1 in s1
+    assert neutron2 in s1
+
+    assert len({proton1, proton2}) == 1
+    assert len({neutron1, neutron2}) == 1
+
+    d = {proton1: 5, neutron2: 3}
+    assert d[proton2] == 5
+    assert d[neutron1] == 3

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -747,8 +747,8 @@ def test_eq_non_unique_pdgids(pdgid1, pdgid2):
 def test_from_name_non_unique_pdgids(name, pdgid):
     """
     Test that Particle.from_name works for p and n, returning the preferred quark representation
-     rather than the representation as a nucleus.
-     """
+    rather than the representation as a nucleus.
+    """
 
     p = Particle.from_name(name)
     assert p.name == name

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -741,7 +741,7 @@ def test_eq_non_unique_pdgids(pdgid1, pdgid2):
     ],
 )
 def test_from_name_non_unique_pdgids(name, pdgid):
-    """The proton and the neutron have two pdgid representations, make sure they still compare equal"""
+    """Test that Particle.fromn_name works for p and n, returning the preferred version"""
 
     p = Particle.from_name(name)
     assert p.name == name

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -728,6 +728,7 @@ def test_eq_non_unique_pdgids(pdgid1, pdgid2):
     p2 = Particle.from_pdgid(pdgid2)
     assert p1.pdgid != p2.pdgid
     assert p1 == p2
+    assert p2 == p1
     assert hash(p1) == hash(p2)
 
 


### PR DESCRIPTION
I added two dicts that are build at import time, one mapping one pdgid to the alternative representation to implement the comparison and one with the "preferred" pdgid used for `__hash__` and to make `from_name` work and always return the same pdgid.

> I chose the "bag of quarks" ids for the "preferred" options, for no particular reason.

Edit: that's actually the official recommendation:

> To avoid ambiguities, nuclear codes should not be applied to a single hadron, like p, n or Λ0, where quark-contents-based codes already exist.

From that I infer though, that neutron and proton are not the only cases, also the delta resonance at least.

Closes https://github.com/scikit-hep/particle/issues/620.