### PR TITLE
Fix the creation of programmatic names for nuclei when the nucleus names end with a 0

### DIFF
--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -979,7 +979,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
     @property
     def programmatic_name(self) -> str:
         "This name could be used for a variable name."
-        return programmatic_name(self.name)
+        return programmatic_name(self.name, self.pdgid.is_nucleus)
 
     @property
     def html_name(self) -> str:

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -18,7 +18,7 @@ def programmatic_name(name: str, is_nucleus: bool) -> str:
     Note
     ----
     The function needs to know if the name relates to a nucleus
-    because zeros at the end of a name charges for all particles except for nuclei.
+    because zeros at the end of a name are charges for all particles except for nuclei.
     Charges need to be make explicit as '_0', as in a(0)(1450)0 or H0,
     whereas in Carbon C10 the last 0 is part of the atomic mass number A.
     """

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -11,9 +11,19 @@ import unicodedata
 from html.entities import name2codepoint
 
 
-def programmatic_name(name: str) -> str:
-    "Return a name safe to use as a variable name."
-    name = re.sub("0$", "_0", name)
+def programmatic_name(name: str, is_nucleus: bool) -> str:
+    """
+    Return a name safe to use as a variable name.
+
+    Note
+    ----
+    The function needs to know if the name relates to a nucleus
+    because zeros at the end of a name charges for all particles except for nuclei.
+    Charges need to be make explicit as '_0', as in a(0)(1450)0 or H0,
+    whereas in Carbon C10 the last 0 is part of the atomic mass number A.
+    """
+    # Last 0 in names is not a charge for nuclei ;-)
+    name = re.sub("0$", "_0", name) if not is_nucleus else name
     # Deal first with antiparticles of sparticles, e.g. "~d(R)~" antiparticle of "~d(R)"
     name = re.sub("^~", "tilde_", name)
     # The remaining "~" now always means it's an antiparticle

--- a/tests/particle/test_utilities.py
+++ b/tests/particle/test_utilities.py
@@ -10,8 +10,41 @@ import pytest
 from particle.particle.utilities import (
     greek_letter_name_to_unicode,
     latex_name_unicode,
+    programmatic_name,
     str_with_unc,
 )
+
+possibilities = (
+    # Particles
+    ("d", "d", False),
+    ("b~", "b_bar", False),
+    ("nu(e)~", "nu_e_bar", False),
+    ("tau+", "tau_plus", False),
+    ("H0", "H_0", False),
+    ("a(2)(1320)0", "a_2_1320_0", False),
+    ("f(2)'(1525)", "f_2p_1525", False),
+    ("Delta(1232)~--", "Delta_1232_mm_bar", False),
+    ("a(0)(1450)0", "a_0_1450_0", False),
+    ("K*(892)0", "Kst_892_0", False),
+    ("K(2)*(1430)~0", "K_2st_1430_0_bar", False),
+    ("D(2)*(2460)+", "D_2st_2460_plus", False),
+    ("B(s2)*(5840)0", "B_s2st_5840_0", False),
+    ("(dd)(1)", "dd_1", False),
+    # Nuclei
+    ("H4", "H4", True),
+    ("He4", "He4", True),
+    ("He4~", "He4_bar", True),
+    ("C10", "C10", True),
+    ("C10~", "C10_bar", True),
+    ("Ag100", "Ag100", True),
+    ("Ag100~", "Ag100_bar", True),
+)
+
+
+@pytest.mark.parametrize(("name", "value", "is_nucleus"), possibilities)
+def test_programmatic_name(name, value, is_nucleus):
+    assert programmatic_name(name, is_nucleus) == value
+
 
 possibilities = (
     (1.234567, 0.01, None, "1.235 ± 0.010"),


### PR DESCRIPTION
Closes https://github.com/scikit-hep/particle/issues/667.