### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Test package
         run: uvx nox -s tests --force-python=${{ matrix.python-version }}
@@ -79,7 +79,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Install package
         run: uv pip install --system -e .[test]


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos