### PR TITLE
feat: drop Python 3.9 and start using pattern matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.12", "3.13", "3.14"]
         include:
-          - { os: macos-latest, python-version: "3.9" }
+          - { os: macos-latest, python-version: "3.10" }
           - { os: macos-latest, python-version: "3.13" }
           - { os: macos-latest, python-version: "3.14" }
-          - { os: windows-latest, python-version: "3.9" }
+          - { os: windows-latest, python-version: "3.10" }
           - { os: windows-latest, python-version: "3.13" }
           - { os: windows-latest, python-version: "3.14" }
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or similar (use `--user`, `virtualenv`, etc. if you wish).
 
 ## Strict dependencies
 
-- [Python](http://docs.python-guide.org/en/latest/starting/installation/) (3.9)
+- [Python](http://docs.python-guide.org/en/latest/starting/installation/) (3.10+)
 - [attrs](http://www.attrs.org/en/stable/) provides classes without boilerplate (similar to DataClasses in Python 3.7)
 - [hepunits](https://github.com/scikit-hep/hepunits)\_ provides units for the Scikit-HEP packages
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: particle_demo
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9
+  - python>=3.10
   # Setting recent versions to make the conda solve faster
   - numpy>=1.19.3
   - pandas>=1.24.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "particle"
 description = "Extended PDG particle data and MC identification codes"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Eduardo Rodrigues", email = "eduardo.rodrigues@cern.ch" },
     { name = "Henry Schreiner", email = "henryfs@princeton.edu" },
@@ -32,7 +32,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/particle/converters/bimap.py
+++ b/src/particle/converters/bimap.py
@@ -8,14 +8,12 @@ from __future__ import annotations
 
 import contextlib
 import csv
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from typing import (
     IO,
     Any,
-    Callable,
     Generic,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -25,8 +23,8 @@ from ..typing import HasOpen, HasRead, StringOrIO
 
 A = TypeVar("A")
 B = TypeVar("B")
-A_conv = Callable[[str], Union[A, int]]
-B_conv = Callable[[str], Union[B, int]]
+A_conv = Callable[[str], A | int]
+B_conv = Callable[[str], B | int]
 
 
 class BiMap(Generic[A, B]):

--- a/src/particle/particle/convert.py
+++ b/src/particle/particle/convert.py
@@ -54,11 +54,11 @@ from __future__ import annotations
 
 import os
 import warnings
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import date
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, TextIO, TypeVar
+from typing import Any, TextIO, TypeVar
 
 import numpy as np
 import pandas as pd

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 # Python standard library
 import contextlib
 import csv
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from copy import copy
 from functools import total_ordering
-from typing import Any, Callable, SupportsInt, TypeVar
+from typing import Any, SupportsInt, TypeVar
 
 # External dependencies
 import attr
@@ -533,9 +533,9 @@ class Particle:
         """
         query_as_list = cls.to_list(*args, **kwargs)
         headers = query_as_list[0]
-        rows = zip(*query_as_list[1:])
+        rows = zip(*query_as_list[1:], strict=False)
 
-        return {str(h): r for h, r in zip(headers, rows)}
+        return {str(h): r for h, r in zip(headers, rows, strict=False)}
 
     @classmethod
     def load_table(

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -657,39 +657,40 @@ def three_charge(pdgid: PDGID_TYPE) -> int | None:
     q3 = _digit(pdgid, Location.Nq3)
     sid = _fundamental_id(pdgid)
 
-    if _extra_bits(pdgid) > 0:
-        if is_nucleus(pdgid):  # ion
-            Z_pdgid = Z(pdgid)
-            return None if Z_pdgid is None else 3 * Z_pdgid
-        if is_Qball(pdgid):  # Qball
-            charge = 3 * ((aid // 10) % 10000)
-        else:  # this should never be reached in the present numbering scheme
-            return None  # since extra bits exist only for Q-balls and nuclei
-    elif is_dyon(pdgid):  # Dyon
-        charge = 3 * ((aid // 10) % 1000)
-        # this is half right
-        # the charge sign will be changed below if pid < 0
-        if _digit(pdgid, Location.Nl) == 2:
-            charge = -charge
-    elif 0 < sid <= 100:  # use table
-        charge = ch100[sid - 1]
-        if aid in {1000017, 1000018, 1000034, 1000052, 1000053, 1000054}:
-            charge = 0
-        if aid in {5100061, 5100062}:
-            charge = 6
-    elif _digit(pdgid, Location.Nj) == 0:  # KL, KS, or undefined
-        return 0
-    elif q1 == 0 or (is_Rhadron(pdgid) and q1 == 9):  # mesons
-        if q2 in {3, 5}:
-            charge = ch100[q3 - 1] - ch100[q2 - 1]
-        else:
-            charge = ch100[q2 - 1] - ch100[q3 - 1]
-    elif q3 == 0:  # diquarks
-        charge = ch100[q2 - 1] + ch100[q1 - 1]
-    elif is_baryon(pdgid) or (
-        is_Rhadron(pdgid) and _digit(pdgid, Location.Nl) == 9
-    ):  # baryons
-        charge = ch100[q3 - 1] + ch100[q2 - 1] + ch100[q1 - 1]
+    match _extra_bits(pdgid):
+        case n if n > 0:
+            if is_nucleus(pdgid):  # ion
+                Z_pdgid = Z(pdgid)
+                return None if Z_pdgid is None else 3 * Z_pdgid
+            if is_Qball(pdgid):  # Qball
+                charge = 3 * ((aid // 10) % 10000)
+            else:  # this should never be reached in the present numbering scheme
+                return None  # since extra bits exist only for Q-balls and nuclei
+        case _ if is_dyon(pdgid):  # Dyon
+            charge = 3 * ((aid // 10) % 1000)
+            # this is half right
+            # the charge sign will be changed below if pid < 0
+            if _digit(pdgid, Location.Nl) == 2:
+                charge = -charge
+        case _ if 0 < sid <= 100:  # use table
+            charge = ch100[sid - 1]
+            if aid in {1000017, 1000018, 1000034, 1000052, 1000053, 1000054}:
+                charge = 0
+            if aid in {5100061, 5100062}:
+                charge = 6
+        case _ if _digit(pdgid, Location.Nj) == 0:  # KL, KS, or undefined
+            return 0
+        case _ if q1 == 0 or (is_Rhadron(pdgid) and q1 == 9):  # mesons
+            if q2 in {3, 5}:
+                charge = ch100[q3 - 1] - ch100[q2 - 1]
+            else:
+                charge = ch100[q2 - 1] - ch100[q3 - 1]
+        case _ if q3 == 0:  # diquarks
+            charge = ch100[q2 - 1] + ch100[q1 - 1]
+        case _ if is_baryon(pdgid) or (
+            is_Rhadron(pdgid) and _digit(pdgid, Location.Nl) == 9
+        ):  # baryons
+            charge = ch100[q3 - 1] + ch100[q2 - 1] + ch100[q1 - 1]
 
     if charge is not None and int(pdgid) < 0:
         charge = -charge
@@ -702,29 +703,27 @@ def j_spin(pdgid: PDGID_TYPE) -> int | None:
         return None
     if _fundamental_id(pdgid) > 0:
         fund = _fundamental_id(pdgid)
-        if is_SUSY(pdgid):  # susy particles
-            if 0 < fund < 17:
+        match (is_SUSY(pdgid), fund):
+            case (True, n) if 0 < n < 17:
                 return 1
-            if fund == 21:
+            case (True, 21):
                 return 2
-            if 22 <= fund < 38:
+            case (True, n) if 22 <= n < 38:
                 return 2
-            if fund == 39:
+            case (True, 39):
                 return 4
-        else:  # other particles
-            if 0 < fund < 7:  # 4th generation quarks not dealt with !
+            case (False, n) if 0 < n < 7:
                 return 2
-            if (
-                fund == 9
-            ):  # Alternative ID for the gluon in codes for glueballs to allow a notation in close analogy with that of hadrons
+            case (False, 9):  # Alternative ID for the gluon in glueballs
                 return 3
-            if 10 < fund < 17:  # 4th generation leptons not dealt with !
+            case (False, n) if 10 < n < 17:
                 return 2
-            if 20 < fund < 25:
+            case (False, n) if 20 < n < 25:
                 return 3
-            if fund == 25:
+            case (False, 25):
                 return 1
-            return None
+            case (False, _):
+                return None
     if abs(int(pdgid)) in {1000000010, 1000010010}:  # neutron, proton
         return 2
     if _extra_bits(pdgid) > 0:
@@ -805,44 +804,22 @@ def L(pdgid: PDGID_TYPE) -> int | None:
     nl = (abspid(pdgid) // 10000) % 10
     js = abspid(pdgid) % 10
 
-    if nl == 0:
-        if js in {1, 3}:
+    # L values from (nl, js) combinations using pattern matching
+    match (nl, js):
+        case (0, 1 | 3):
             return 0
-        if js == 5:
+        case (0, 5) | (1, 1 | 3) | (2, 3):
             return 1
-        if js == 7:
+        case (0, 7) | (1, 5) | (2, 5) | (3, 3):
             return 2
-        if js == 9:
+        case (0, 9) | (1, 7) | (2, 7) | (3, 5):
             return 3
-    elif nl == 1:
-        if js in {1, 3}:
-            return 1
-        if js == 5:
-            return 2
-        if js == 7:
-            return 3
-        if js == 9:
+        case (1, 9) | (2, 9) | (3, 7):
             return 4
-    elif nl == 2:
-        if js == 3:
-            return 1
-        if js == 5:
-            return 2
-        if js == 7:
-            return 3
-        if js == 9:
-            return 4
-    elif nl == 3:
-        if js == 3:
-            return 2
-        if js == 5:
-            return 3
-        if js == 7:
-            return 4
-        if js == 9:
+        case (3, 9):
             return 5
-
-    return 0
+        case _:
+            return 0
 
 
 def l_spin(pdgid: PDGID_TYPE) -> int | None:

--- a/src/particle/pdgid/functions.py
+++ b/src/particle/pdgid/functions.py
@@ -657,40 +657,39 @@ def three_charge(pdgid: PDGID_TYPE) -> int | None:
     q3 = _digit(pdgid, Location.Nq3)
     sid = _fundamental_id(pdgid)
 
-    match _extra_bits(pdgid):
-        case n if n > 0:
-            if is_nucleus(pdgid):  # ion
-                Z_pdgid = Z(pdgid)
-                return None if Z_pdgid is None else 3 * Z_pdgid
-            if is_Qball(pdgid):  # Qball
-                charge = 3 * ((aid // 10) % 10000)
-            else:  # this should never be reached in the present numbering scheme
-                return None  # since extra bits exist only for Q-balls and nuclei
-        case _ if is_dyon(pdgid):  # Dyon
-            charge = 3 * ((aid // 10) % 1000)
-            # this is half right
-            # the charge sign will be changed below if pid < 0
-            if _digit(pdgid, Location.Nl) == 2:
-                charge = -charge
-        case _ if 0 < sid <= 100:  # use table
-            charge = ch100[sid - 1]
-            if aid in {1000017, 1000018, 1000034, 1000052, 1000053, 1000054}:
-                charge = 0
-            if aid in {5100061, 5100062}:
-                charge = 6
-        case _ if _digit(pdgid, Location.Nj) == 0:  # KL, KS, or undefined
-            return 0
-        case _ if q1 == 0 or (is_Rhadron(pdgid) and q1 == 9):  # mesons
-            if q2 in {3, 5}:
-                charge = ch100[q3 - 1] - ch100[q2 - 1]
-            else:
-                charge = ch100[q2 - 1] - ch100[q3 - 1]
-        case _ if q3 == 0:  # diquarks
-            charge = ch100[q2 - 1] + ch100[q1 - 1]
-        case _ if is_baryon(pdgid) or (
-            is_Rhadron(pdgid) and _digit(pdgid, Location.Nl) == 9
-        ):  # baryons
-            charge = ch100[q3 - 1] + ch100[q2 - 1] + ch100[q1 - 1]
+    if _extra_bits(pdgid) > 0:
+        if is_nucleus(pdgid):  # ion
+            Z_pdgid = Z(pdgid)
+            return None if Z_pdgid is None else 3 * Z_pdgid
+        if is_Qball(pdgid):  # Qball
+            charge = 3 * ((aid // 10) % 10000)
+        else:  # this should never be reached in the present numbering scheme
+            return None  # since extra bits exist only for Q-balls and nuclei
+    elif is_dyon(pdgid):  # Dyon
+        charge = 3 * ((aid // 10) % 1000)
+        # this is half right
+        # the charge sign will be changed below if pid < 0
+        if _digit(pdgid, Location.Nl) == 2:
+            charge = -charge
+    elif 0 < sid <= 100:  # use table
+        charge = ch100[sid - 1]
+        if aid in {1000017, 1000018, 1000034, 1000052, 1000053, 1000054}:
+            charge = 0
+        if aid in {5100061, 5100062}:
+            charge = 6
+    elif _digit(pdgid, Location.Nj) == 0:  # KL, KS, or undefined
+        return 0
+    elif q1 == 0 or (is_Rhadron(pdgid) and q1 == 9):  # mesons
+        if q2 in {3, 5}:
+            charge = ch100[q3 - 1] - ch100[q2 - 1]
+        else:
+            charge = ch100[q2 - 1] - ch100[q3 - 1]
+    elif q3 == 0:  # diquarks
+        charge = ch100[q2 - 1] + ch100[q1 - 1]
+    elif is_baryon(pdgid) or (
+        is_Rhadron(pdgid) and _digit(pdgid, Location.Nl) == 9
+    ):  # baryons
+        charge = ch100[q3 - 1] + ch100[q2 - 1] + ch100[q1 - 1]
 
     if charge is not None and int(pdgid) < 0:
         charge = -charge
@@ -703,27 +702,29 @@ def j_spin(pdgid: PDGID_TYPE) -> int | None:
         return None
     if _fundamental_id(pdgid) > 0:
         fund = _fundamental_id(pdgid)
-        match (is_SUSY(pdgid), fund):
-            case (True, n) if 0 < n < 17:
+        if is_SUSY(pdgid):  # susy particles
+            if 0 < fund < 17:
                 return 1
-            case (True, 21):
+            if fund == 21:
                 return 2
-            case (True, n) if 22 <= n < 38:
+            if 22 <= fund < 38:
                 return 2
-            case (True, 39):
+            if fund == 39:
                 return 4
-            case (False, n) if 0 < n < 7:
+        else:  # other particles
+            if 0 < fund < 7:  # 4th generation quarks not dealt with !
                 return 2
-            case (False, 9):  # Alternative ID for the gluon in glueballs
+            if (
+                fund == 9
+            ):  # Alternative ID for the gluon in codes for glueballs to allow a notation in close analogy with that of hadrons
                 return 3
-            case (False, n) if 10 < n < 17:
+            if 10 < fund < 17:  # 4th generation leptons not dealt with !
                 return 2
-            case (False, n) if 20 < n < 25:
+            if 20 < fund < 25:
                 return 3
-            case (False, 25):
+            if fund == 25:
                 return 1
-            case (False, _):
-                return None
+            return None
     if abs(int(pdgid)) in {1000000010, 1000010010}:  # neutron, proton
         return 2
     if _extra_bits(pdgid) > 0:

--- a/src/particle/typing.py
+++ b/src/particle/typing.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import IO, Any, Protocol, Union, runtime_checkable
+from typing import IO, Any, Protocol, runtime_checkable
 
 from ._compat.typing import Traversable
 
@@ -17,7 +17,7 @@ __all__ = (
 )
 
 
-StringOrIO = Union[Traversable, IO[str], str]
+StringOrIO = Traversable | IO[str] | str
 
 
 @runtime_checkable


### PR DESCRIPTION
This was testing a SKILL.md file (first one I've written) for dropping 3.9 (https://github.com/henryiii/skills/blob/main/drop_python3.9/SKILL.md). I was iterating on writing it, so if you rerun it it might behave a bit different (or using a different model, etc; I'm using nrp.ai, copilot and others support skills too).

:robot: Assisted-by: OpenCode: Kimi-K2.5

- **feat: drop Python 3.9**
- **chore: use pattern matching**
