### PR TITLE
fix: to_list/to_dict ignored search terms when no filter_fn given

### DIFF
--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -408,12 +408,8 @@ class Particle:
                 with contextlib.suppress(ValueError):
                     tbl_names.remove(fld)
 
-        # Start with the full table
-        tbl_all = sorted(cls.all())
-
-        # Apply a filter, if specified
-        if filter_fn is not None:
-            tbl_all = cls.findall(filter_fn, particle=particle, **search_terms)
+        # Apply a filter if specified; with all-None arguments findall returns the full table
+        tbl_all = cls.findall(filter_fn, particle=particle, **search_terms)
 
         # In any case, only keep a given number of rows?
         if n_rows >= 0:

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -664,7 +664,7 @@ def test_to_dict() -> None:
 
 
 def test_to_list_search_terms_without_filter_fn() -> None:
-    # Regression: search_terms were silently ignored when filter_fn was not given.
+    # Test the search when filter_fn is not given.
     tbl = Particle.to_list(pdg_name="tau", exclusive_fields=["pdgid"])
     # Header row + tau (15) + anti-tau (-15)
     assert len(tbl) == 3
@@ -674,7 +674,7 @@ def test_to_list_search_terms_without_filter_fn() -> None:
 
 
 def test_to_list_particle_kwarg_without_filter_fn() -> None:
-    # Regression: the particle= keyword was silently ignored when filter_fn was not given.
+    # Test that the particle= keyword is not silently ignored when filter_fn is not given.
     tbl = Particle.to_list(particle=True, n_rows=5, exclusive_fields=["pdgid"])
     pdgids = [int(row[0]) for row in tbl[1:]]  # skip header
     assert all(pid > 0 for pid in pdgids)

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -663,6 +663,23 @@ def test_to_dict() -> None:
     assert set(query_as_dict["name"]) == {"e+", "mu+", "tau+", "tau'+"}
 
 
+def test_to_list_search_terms_without_filter_fn() -> None:
+    # Regression: search_terms were silently ignored when filter_fn was not given.
+    tbl = Particle.to_list(pdg_name="tau", exclusive_fields=["pdgid"])
+    # Header row + tau (15) + anti-tau (-15)
+    assert len(tbl) == 3
+    assert ["pdgid"] in tbl
+    assert [15] in tbl
+    assert [-15] in tbl
+
+
+def test_to_list_particle_kwarg_without_filter_fn() -> None:
+    # Regression: the particle= keyword was silently ignored when filter_fn was not given.
+    tbl = Particle.to_list(particle=True, n_rows=5, exclusive_fields=["pdgid"])
+    pdgids = [int(row[0]) for row in tbl[1:]]  # skip header
+    assert all(pid > 0 for pid in pdgids)
+
+
 decfile_style_names = (
     ("s", 3),
     ("anti-b", -5),


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

**Bug:** `Particle.to_list(**search_terms)` and `Particle.to_list(particle=...)` silently returned the entire table (6506 rows) when `filter_fn` was not given, because `search_terms` and `particle` were only forwarded to `findall` inside an `if filter_fn is not None:` guard.

**Before:**
```python
>>> Particle.to_list(pdg_name="tau", exclusive_fields=["pdgid"])
# returned all 6506 particles, not just tau/anti-tau
```

**After:**
```python
>>> Particle.to_list(pdg_name="tau", exclusive_fields=["pdgid"])
[['pdgid'], [15], [-15]]  # only the two tau rows
```

**Fix:** Call `cls.findall(filter_fn, particle=particle, **search_terms)` unconditionally. With all-None/empty arguments `findall` returns the full table, preserving the no-filter behavior. The redundant `sorted(cls.all())` (computed then discarded whenever a filter was present) is eliminated as a side effect.

Two regression tests are added:
- `test_to_list_search_terms_without_filter_fn`: asserts `pdg_name="tau"` yields exactly the header + tau (15) + anti-tau (−15).
- `test_to_list_particle_kwarg_without_filter_fn`: asserts `particle=True` yields only positive PDG IDs.

Addresses one item of #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)