### PR TITLE
fix: friendly CLI errors and required subcommand in python -m particle

### DIFF
--- a/src/particle/__main__.py
+++ b/src/particle/__main__.py
@@ -12,6 +12,7 @@ import sys
 
 from . import __version__
 from .particle import Particle
+from .particle.particle import InvalidParticle, ParticleNotFound
 from .pdgid import PDGID
 
 
@@ -27,7 +28,9 @@ def main() -> None:
         version=f"%(prog)s {__version__}",
     )
 
-    subparsers = parser.add_subparsers(help="Subcommands")
+    subparsers = parser.add_subparsers(
+        help="Subcommands", required=True, dest="command"
+    )
 
     search = subparsers.add_parser(
         "search",
@@ -44,18 +47,18 @@ def main() -> None:
 
     if "particle" in opts:
         for cand in opts.particle:
-            if hasattr(cand, "decode"):
-                cand = cand.decode("utf-8")  # noqa: PLW2901
-
             try:
                 value = int(cand)
             except ValueError:
                 value = 0
 
-            if value:
-                particles = [Particle.from_pdgid(value)]
-            else:
-                particles = Particle.findall(cand)
+            try:
+                if value:
+                    particles = [Particle.from_pdgid(value)]
+                else:
+                    particles = Particle.findall(cand)
+            except (InvalidParticle, ParticleNotFound):
+                particles = []
 
             if not particles:
                 print("Particle", cand, "not found.")
@@ -70,9 +73,13 @@ def main() -> None:
 
     if "pdgid" in opts:
         for value in opts.pdgid:
-            p = PDGID(value)
+            try:
+                p = PDGID(value)
+            except ValueError:
+                print(f"Invalid PDG ID: {value!r}")
+                sys.exit(1)
             print(p)
-            print(PDGID(value).info())
+            print(p.info())
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2018-2026, Eduardo Rodrigues and Henry Schreiner.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/particle for details.
+
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "particle", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_no_subcommand_exits_2() -> None:
+    result = run_cli()
+    assert result.returncode == 2
+    assert "usage:" in result.stderr.lower()
+
+
+def test_search_valid_particle() -> None:
+    result = run_cli("search", "D0")
+    assert result.returncode == 0
+    assert "Name: D0" in result.stdout
+
+
+def test_search_unknown_pdgid() -> None:
+    result = run_cli("search", "99999999")
+    assert result.returncode == 1
+    assert "not found" in result.stdout.lower()
+
+
+def test_search_unknown_name() -> None:
+    result = run_cli("search", "NoSuchParticle")
+    assert result.returncode == 1
+    assert "not found" in result.stdout.lower()
+
+
+def test_pdgid_valid() -> None:
+    result = run_cli("pdgid", "11")
+    assert result.returncode == 0
+    assert "11" in result.stdout
+
+
+def test_pdgid_invalid() -> None:
+    result = run_cli("pdgid", "abc")
+    assert result.returncode == 1
+    assert "Invalid PDG ID" in result.stdout
+    assert "'abc'" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "particle", *args],
         capture_output=True,
+        check=False,
         text=True,
     )
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Addresses the CLI items of #772.

**Before / After**

| Scenario | Before | After |
|---|---|---|
| `python -m particle` (no subcommand) | silently exits 0, prints nothing | prints usage, exits 2 |
| `python -m particle pdgid abc` | `ValueError` traceback | `Invalid PDG ID: 'abc'`, exits 1 |
| `python -m particle search 99999999` | `InvalidParticle` / `ParticleNotFound` traceback | `Particle 99999999 not found.`, exits 1 |
| `python -m particle search D0` | works | still works |

## Changes

- **Required subcommand** — `parser.add_subparsers(..., required=True, dest="command")` so argparse prints usage and exits 2 when no subcommand is given.
- **Friendly error for `pdgid abc`** — wrap `PDGID(value)` in a `try/except ValueError`; print `Invalid PDG ID: 'abc'` and `sys.exit(1)`.
- **Friendly error for `search 99999999`** — catch `InvalidParticle` and `ParticleNotFound` from `Particle.from_pdgid`; route them into the existing "Particle X not found." + `sys.exit(1)` path.
- **Remove Python-2 relic** — delete the `if hasattr(cand, "decode"): cand = cand.decode("utf-8")` block; argv items are always `str` on Python 3.
- **Use `p.info()` instead of `PDGID(value).info()`** — avoids constructing a second PDGID object.
- **New `tests/test_cli.py`** — 6 subprocess-based tests covering all fixed scenarios plus the normal happy path.

## Test plan

- [x] `uv run pytest` — all 567 tests pass (6 new in `tests/test_cli.py`)
- [x] `prek -a --quiet` — clean
- [x] `python -m particle` → usage + exit 2
- [x] `python -m particle pdgid abc` → `Invalid PDG ID: 'abc'` + exit 1
- [x] `python -m particle search 99999999` → `Particle 99999999 not found.` + exit 1
- [x] `python -m particle search D0` → correct output + exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)