### PR TITLE
chore: drop unused typing-extensions dependency and fix config pins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         files: src|tests
         exclude: ^tests/utils
         additional_dependencies:
-          [attrs==21.4.0, hepunits>=2.2.0, pytest, pytest-benchmark]
+          [attrs>=22.2.0, hepunits>=2.2.0, pytest, pytest-benchmark]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,7 +64,6 @@ def zipapp(session: nox.Session) -> None:
         "install",
         "--no-compile",
         ".",
-        "typing_extensions",
         f"--target={tmpdir}",
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
 dependencies = [
     "attrs>=22.2.0",
     "hepunits>=2.4.0",
-    "typing-extensions>=4.5;python_version<\"3.13\"",
 ]
 dynamic = ["version"]
 
@@ -205,7 +204,7 @@ particle  = { path = ".", editable = true}
 
 [tool.pixi.dependencies]
 numpy = ">=1.19.3"
-pandas = ">=1.24.0"
+pandas = ">=2.0"
 attrs = ">=22.2.0"
 jupyterlab = ">=4"
 tabulate = "*"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- **Drop `typing-extensions` runtime dependency**: Verified by `grep -rn "typing_extensions" src/ tests/` — no usages anywhere in `src/` or `tests/`. Remove from `[project] dependencies` in `pyproject.toml`. Also remove the explicit `typing_extensions` install in the `zipapp` nox session, which existed only to bundle this now-unnecessary dependency.
- **Fix `[tool.pixi.dependencies]` pandas floor**: `pandas = ">=1.24.0"` was a numpy version number accidentally used as the pandas floor. Changed to `pandas = ">=2.0"` (a real pandas version), which is a no-op in practice since the project already requires modern pandas, but removes the misleading false floor.
- **Align mypy pre-commit hook attrs pin**: The mypy hook specified `attrs==21.4.0` in `additional_dependencies`, one major version older than the runtime floor `attrs>=22.2.0`. Updated to `attrs>=22.2.0` so type-checking runs against a supported attrs version.

## Verification

- `grep -rn "typing_extensions" src/ tests/` — no output, confirming no usages
- `prek -a --quiet` — passed cleanly (all pre-commit hooks, including mypy with updated attrs)
- `uv run --extra test pytest tests/particle/test_particle.py -q` — **395 passed**
- `uv run --extra test pytest -q` — **561 passed**
- `uv run nox -s zipapp` — skipped: Python 3.10 interpreter not available in this environment (nox cannot download it without the `[pbs]` extra). The change is a one-line removal of `"typing_extensions"` from a pip install list; the installed package no longer declares this as a dependency, so it will not be pulled in.

Addresses packaging/modernization items of #772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)