### PR TITLE
fix: assorted small correctness fixes (from_name, str_with_unc, load_table, messages)

### DIFF
--- a/src/particle/converters/evtgen.py
+++ b/src/particle/converters/evtgen.py
@@ -51,7 +51,7 @@ Directional map between EvtGen and names.
 Examples
 --------
 >>> EvtGen2PDGNameMap['J/psi']
->>> 'J/psi(1S)'
+'J/psi(1S)'
 """
 
 del BiMap

--- a/src/particle/geant/geant3id.py
+++ b/src/particle/geant/geant3id.py
@@ -47,7 +47,7 @@ class Geant3ID(int):
     'pi+'
     """
 
-    __slots__ = ()  # Keep PythiaID a slots based class
+    __slots__ = ()  # Keep Geant3ID a slots based class
 
     @classmethod
     def from_pdgid(cls: type[Self], pdgid: int) -> Self:

--- a/src/particle/particle/kinematics.py
+++ b/src/particle/particle/kinematics.py
@@ -50,7 +50,7 @@ def width_to_lifetime(Gamma: float) -> float:
     """
 
     if Gamma < 0.0:
-        raise ValueError(f"Input provided, {Gamma} <= 0!")
+        raise ValueError(f"Input provided, {Gamma} < 0!")
     if Gamma == 0:
         return float("inf")
 
@@ -70,7 +70,7 @@ def lifetime_to_width(tau: float) -> float:
     Returns
     -------
     Particle decay width, in the HEP standard energy unit MeV.
-    tau > 0: particle lifetime, in the HEP standard time unit ns.
+    tau > 0: particle decay width, in the HEP standard energy unit MeV.
     tau = 0: Infinity (float("inf")).
     tau < 0: an exception ValueError is raised.
 
@@ -96,7 +96,7 @@ def lifetime_to_width(tau: float) -> float:
     """
 
     if tau < 0:
-        raise ValueError(f"Input provided, {tau} <= 0!")
+        raise ValueError(f"Input provided, {tau} < 0!")
     if tau == 0:
         return float("inf")
 

--- a/src/particle/particle/particle.py
+++ b/src/particle/particle/particle.py
@@ -557,6 +557,9 @@ class Particle:
 
         if append and not cls.table_loaded():
             cls.load_table(append=False)  # default load
+            if filename is None:
+                # Default data already loaded; nothing more to do.
+                return
         elif not append:
             cls._table = []
             cls._hash_table = {}
@@ -1182,7 +1185,10 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             def find_preferred_id(p: Self) -> bool:
                 return int(p.pdgid) in _PREFERRED_PDGID.values()
 
-            return next(filter(find_preferred_id, cls.finditer(name=name)))
+            result = next(filter(find_preferred_id, cls.finditer(name=name)), None)
+            if result is None:
+                raise ParticleNotFound(f"Could not find name {name!r}")
+            return result
         try:
             (particle,) = cls.finditer(
                 name=name
@@ -1256,7 +1262,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             )
         if z < 0 or z > 999:
             raise InvalidParticle(
-                f"Atomic number Z={z} is invalid. Must be 0 <= A <= 999."
+                f"Atomic number Z={z} is invalid. Must be 0 <= Z <= 999."
             )
         if a < 0 or a > 999:
             raise InvalidParticle(
@@ -1268,7 +1274,7 @@ C (charge parity) = {C:<6}  I (isospin)       = {self.I!s:<7}  G (G-parity)     
             )
         if z > a:
             raise InvalidParticle(
-                f"Nucleus A={a}, Z={z} is invalid. Z must be smaller or equal to Z."
+                f"Nucleus A={a}, Z={z} is invalid. Z must be smaller or equal to A."
             )
 
         pdgid = int(1e9 + l_strange * 1e5 + z * 1e4 + a * 10 + i)

--- a/src/particle/particle/utilities.py
+++ b/src/particle/particle/utilities.py
@@ -68,6 +68,14 @@ def str_with_unc(value: float, upper: float | None, lower: float | None = None) 
     if error == 0:
         return str(value)
 
+    if value == 0:
+        # log10(0) is undefined; format with the error's significant digits
+        error_digits = math.floor(math.log10(error) - math.log10(2.5))
+        fse = f".{-error_digits}f" if error_digits < 0 else ".0f"
+        if upper != lower:
+            return f"{value:{fse}} + {upper:{fse}} - {lower:{fse}}"
+        return f"{value:{fse}} ± {upper:{fse}}"
+
     value_digits = math.floor(math.log10(value))
     error_digits = math.floor(math.log10(error) - math.log10(2.5))
     # This is split based on the value being larger than 1000000 or smaller than 0.001 - scientific notation split

--- a/tests/particle/test_kinematics.py
+++ b/tests/particle/test_kinematics.py
@@ -20,9 +20,9 @@ def test_valid_width_lifetime_conversions() -> None:
 
 
 def test_invalid_width_lifetime_conversions() -> None:
-    with pytest.raises(ValueError, match="Input provided, -1 <= 0!"):
+    with pytest.raises(ValueError, match="Input provided, -1 < 0!"):
         lifetime_to_width(-1)
-    with pytest.raises(ValueError, match="Input provided, -1 <= 0!"):
+    with pytest.raises(ValueError, match="Input provided, -1 < 0!"):
         width_to_lifetime(-1)
 
     assert lifetime_to_width(0) == float("inf")

--- a/tests/particle/test_particle.py
+++ b/tests/particle/test_particle.py
@@ -408,6 +408,57 @@ def test_all_particles_are_loaded() -> None:
     Particle.load_table()
 
 
+def test_load_table_append_true_no_duplicate_on_fresh_state() -> None:
+    """
+    load_table(append=True) on a completely unloaded table (i.e. _table is None)
+    with filename=None should produce exactly the default two-file table,
+    not duplicate it.  This guards against a regression where defaults were read twice.
+    """
+    saved_table = Particle._table
+    saved_hash = Particle._hash_table
+    saved_names = Particle._table_names
+    try:
+        # Simulate the "never loaded" state
+        Particle._table = None
+        Particle._hash_table = None
+        Particle._table_names = None
+        assert not Particle.table_loaded()
+        Particle.load_table(append=True)
+        assert Particle.table_names() == ("particle2026.csv", "nuclei2026.csv")
+    finally:
+        Particle._table = saved_table
+        Particle._hash_table = saved_hash
+        Particle._table_names = saved_names
+        Particle.load_table()  # restore global state
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["p", "n", "p~", "n~"],
+)
+def test_from_name_special_particles_partinotfound_on_empty_table(
+    name: str,
+) -> None:
+    """
+    from_name raises ParticleNotFound (not bare StopIteration) for the special
+    p/n/p~/n~ branch when the table does not contain those entries.
+    """
+    import io
+
+    # Load a minimal table that has no p/n entries
+    minimal_csv = (
+        "ID,Mass,MassUpper,MassLower,Width,WidthUpper,WidthLower,"
+        "I,G,P,C,Anti,Charge,Rank,Status,Name,Quarks,Latex\n"
+        "22,0.0,0.0,0.0,0.0,0.0,0.0,5,5,5,5,5,0,0,0,gamma,,\\gamma\n"
+    )
+    try:
+        Particle.load_table(io.StringIO(minimal_csv), _name="minimal_test.csv")
+        with pytest.raises(ParticleNotFound):
+            Particle.from_name(name)
+    finally:
+        Particle.load_table()  # restore global state
+
+
 checklist_html_name = (
     (22, "&#x03b3;"),  # photon
     (1, "d"),  # d quark

--- a/tests/particle/test_utilities.py
+++ b/tests/particle/test_utilities.py
@@ -61,6 +61,8 @@ possibilities_2 = (
     (1234.5, 2, 2, "1234.5 ± 2.0"),
     (1234.5, None, None, "1234.5"),
     (1234.5, None, 2, "1234.5"),
+    # value == 0 with nonzero uncertainty must not raise ValueError
+    (0.0, 1e-9, 1e-9, "0.0000000000 ± 0.0000000010"),
 )
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Addresses several small bug items of #772.

- **`from_name` StopIteration → ParticleNotFound**: the special branch for `{"p","n","p~","n~"}` used bare `next(filter(...))` which raises `StopIteration` instead of `ParticleNotFound` when those entries are absent from a user-replaced table. Fixed to use `next(..., None)` with an explicit raise.
- **`str_with_unc` zero-value crash**: `math.log10(0)` raised `ValueError: math domain error` when `value == 0` with a nonzero uncertainty (reachable via `describe()`/`repr()` on user-table particles). Added an early guard that formats using only the error's significant digits.
- **`load_table(append=True)` double-read**: calling `load_table(append=True)` with `filename=None` on a fresh unloaded table read the default CSVs twice (four `table_names` entries instead of two). Fixed by returning early after the recursive default load when `filename is None`.
- **`from_nucleus_info` error messages**: Z-range check said `"Must be 0 <= A <= 999"` (should be Z); the `z > a` check said `"Z must be smaller or equal to Z"` (should be A).
- **`kinematics.py` error messages and docstring**: `ValueError` raised on `< 0` input but messages said `<= 0` (0 is valid, returning `inf`). Also fixed the `lifetime_to_width` Returns docstring that was copy-pasted from `width_to_lifetime` and described a lifetime instead of a width.
- **`evtgen.py` docstring**: `EvtGen2PDGNameMap.__doc__` example had `>>> 'J/psi(1S)'` — the expected output line incorrectly had `>>>`. Removed it.
- **`geant3id.py` comment**: `# Keep PythiaID a slots based class` was a copy-paste error; corrected to `Geant3ID`.

Tests added for `str_with_unc(0.0, 1e-9, 1e-9)`, `from_name` raising `ParticleNotFound` on the special names when the table lacks those entries, and `load_table(append=True)` not duplicating `table_names`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)