### PR TITLE
fix(ci): give the publish job contents write permission for the zipapp release upload

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
           path: particle.pyz
 
   publish:
-    needs: [dist]
+    needs: [dist, zipapp]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     environment:
@@ -57,6 +57,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
+      contents: write
 
     steps:
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The publish job's explicit `permissions` block dropped the default `contents: write`, so `softprops/action-gh-release` failed with "Resource not accessible by integration" when it attached `particle.pyz` to the release. This adds `contents: write` and makes `publish` depend on the `zipapp` job it downloads from.

Fixes #784